### PR TITLE
Changes to AWS cloud config

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -142,14 +142,16 @@ class Cloud(object):
         priv, pub = saltcloud.utils.gen_keys(
                 saltcloud.utils.get_option('keysize', self.opts, vm_)
                 )
-        saltcloud.utils.accept_key(self.opts['pki_dir'], pub, vm_['name'])
         vm_['pub_key'] = pub
         vm_['priv_key'] = priv
+        ok = False
         try:
-            self.clouds['{0}.create'.format(self.provider(vm_))](vm_)
+            ok = self.clouds['{0}.create'.format(self.provider(vm_))](vm_)
         except KeyError as exc:
             print('Failed to create vm {0}. Configuration value {1} needs '
                   'to be set'.format(vm_['name'], exc))
+        if ok != False:
+            saltcloud.utils.accept_key(self.opts['pki_dir'], pub, vm_['name'])
 
     def run_profile(self):
         '''

--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -121,6 +121,25 @@ def get_location(vm_):
     return vm_.get('location', __opts__.get('AWS.location', DEFAULT_LOCATION))
 
 
+def get_availability_zone(conn, vm_):
+    '''
+    Return the availability zone to use
+    '''
+    locations = conn.list_locations()
+    az = None
+    if 'availability_zone' in vm_:
+        az = vm_['availability_zone']
+    elif 'EC2.availability_zone' in __opts__:
+        az = __opts__['EC2.availability_zone']
+
+    if az is None:
+        # Default to first zone
+        return locations[0]
+    for loc in locations:
+        if loc.availability_zone.name == az:
+            return loc
+
+
 def create(vm_):
     '''
     Create a single vm from a data dict
@@ -134,6 +153,7 @@ def create(vm_):
     deploy_script = script(vm_)
     kwargs['image'] = get_image(conn, vm_)
     kwargs['size'] = get_size(conn, vm_)
+    kwargs['location'] = get_availability_zone(conn, vm_)
     ex_keyname = keyname(vm_)
     if ex_keyname:
         kwargs['ex_keyname'] = ex_keyname

--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -112,6 +112,13 @@ def securitygroup(vm_):
     return str(vm_.get('AWS.securitygroup', __opts__.get('AWS.securitygroup', 'default')))
 
 
+def ssh_username(vm_):
+    '''
+    Return the ssh_username. Defaults to 'ec2-user'.
+    '''
+    return vm_.get('ssh_username', __opts__.get('AWS.ssh_username', 'ec2-user'))
+
+
 def get_location(vm_):
     '''
     Return the AWS region to use
@@ -145,7 +152,7 @@ def create(vm_):
     location = get_location(vm_)
     print('Creating Cloud VM {0} in {1}'.format(vm_['name'], location))
     conn = get_conn(location=location)
-    kwargs = {'ssh_username': 'ec2-user',
+    kwargs = {'ssh_username': ssh_username(vm_),
               'ssh_key': __opts__['AWS.private_key']}
     kwargs['name'] = vm_['name']
     deploy_script = script(vm_)
@@ -180,7 +187,7 @@ def create(vm_):
             fp_.write(deploy_script.script)
         cmd = ('scp -oStrictHostKeyChecking=no -i {0} {3} {1}@{2}:/tmp/deploy.sh ').format(
                        __opts__['AWS.private_key'],
-                       'ec2-user',
+                       kwargs['ssh_username'],
                        data.public_ips[0],
                        path,
                        )
@@ -203,7 +210,7 @@ def create(vm_):
             cmd = ('ssh -oStrictHostKeyChecking=no -t -i {0} {1}@{2} '
                    '"sudo bash /tmp/deploy.sh"').format(
                        __opts__['AWS.private_key'],
-                       'ec2-user',
+                       kwargs['ssh_username'],
                        data.public_ips[0],
                        )
         subprocess.call(cmd, shell=True)

--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -107,12 +107,10 @@ def keyname(vm_):
 
 def securitygroup(vm_):
     '''
-    Return the keyname
+    Return the security group
     '''
-    return str(vm_.get(
-            'AWS.securitygroup',
-            __opts__.get('AWS.securitygroup', 'default')
-            ))
+    return str(vm_.get('AWS.securitygroup', __opts__.get('AWS.securitygroup', 'default')))
+
 
 def get_location(vm_):
     '''


### PR DESCRIPTION
Hey Thomas,

So I finally raised the PR :) There's a few changes, all of which were needed to get my requirements working with AWS:
- Support for AWS regions, called 'location' in salt-cloud
- Support for availability zones, called 'availability_zones' in salt-cloud
- Can configure the username when connecting over SSH
- Can specific internal or external IPs to connect with (I run salt-cloud within the AWS data centre, so need internal)
- A small fix to only accept keys if no errors occur in create()

I also wanted to update the help files, but ran out of time. Here's my current config which should make this all make more sense:

/etc/salt/cloud:

```
    # set default config passed to all minions
    minion:
      master: salt.basketchaser.com
     
    # set the AWS login data
    AWS.id: <id>
    AWS.key: <key>
    AWS.keyname: <keyname>
    AWS.securitygroup: default
    AWS.private_key: /root/key.pem
    AWS.ssh_username: ubuntu
     
    # set default cloud provider to AWS
    provider: aws
     
    # set our default region for AWS
    AWS.location: ap-southeast-1
    AWS.availability_zone: ap-southeast-1b
    AWS.ssh_interface: private_ips
```

/etc/salt/cloud.profiles:

```
    base_aws:
      provider: aws
      image: ami-a6ca8df4
      size: Small Instance
      os: Ubuntu
      minion:
        grains:
          role: app
```
