### PR TITLE
write /etc/salt before installing salt-minion on Ubuntu deploy.

### DIFF
--- a/saltcloud/deploy/Ubuntu.sh
+++ b/saltcloud/deploy/Ubuntu.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
+mkdir -p /etc/salt/pki
+echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
+echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
+echo "{{ minion }}" > /etc/salt/minion
+
 apt-get update
 apt-get install -y python-software-properties
 echo | add-apt-repository  ppa:saltstack/salt
 apt-get update
 apt-get install -y salt-minion
-mkdir -p /etc/salt/pki
-echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
-echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
-echo "{{ minion }}" > /etc/salt/minion
-service salt-minion restart


### PR DESCRIPTION
This fix for #25 means we don't need to restart the minion at all.
