### PR TITLE
Notify user when a VM name already exists

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -165,6 +165,7 @@ class Cloud(object):
                     found = True
                     if name in pmap.get(self.provider(vm_), []):
                         # The specified vm already exists, don't make it anew
+                        print("{0} already exists on {1}".format(name, self.provider(vm_)))
                         continue
                     vm_['name'] = name
                     if self.opts['parallel']:


### PR DESCRIPTION
Previously, salt-cloud only returned to command line with no messages
