### PR TITLE
Updated error message handling for create/deploy

### DIFF
--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -120,12 +120,10 @@ def create(vm_):
     try:
         data = conn.create_node(**kwargs)
     except Exception as exc:
-        err = ('The following exception was thrown by libcloud when trying to '
-               'run the initial deployment: \n{0}\n\nThe vm {1} has been '
-               'created but Salt could not be intsalled. Please verify that '
-               'your ssh keys are in order and that the security group is '
-               'accepting inbound connections from port 22.\n').format(
-                       exc, vm_['name']
+        err = ('Error creating {0} on AWS\n\n'
+               'The following exception was thrown by libcloud when trying to '
+               'run the initial deployment: \n{1}').format(
+                       vm_['name'], exc
                        )
         sys.stderr.write(err)
         return False

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -79,8 +79,13 @@ def create(vm_):
         data = conn.deploy_node(**kwargs)
     except Exception as exc:
         message = str(exc)
-        print('The following error was returned: {0}'.format(message))
-        return
+        err = ('Error creating {0} on GOGRID\n\n'
+               'The following exception was thrown by libcloud when trying to '
+               'run the initial deployment: \n{1}').format(
+                       vm_['name'], message
+                       )
+        sys.stderr.write(err)
+        return False
     print('Created Cloud VM {0} with the following values:'.format(
         vm_['name']
         ))

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -79,8 +79,13 @@ def create(vm_):
     try:
         data = conn.create_node(**kwargs)
     except Exception as exc:
-        print('JoyEnt returned the following error: {0}'.format(exc.message))
-        return
+        err = ('Error creating {0} on JOYENT\n\n'
+               'The following exception was thrown by libcloud when trying to '
+               'run the initial deployment: \n{1}').format(
+                       vm_['name'], exc.message
+                       )
+        sys.stderr.write(err)
+        return False
     if saltcloud.utils.wait_for_ssh(data.public_ips[0]):
         cmd = ('ssh -oStrictHostKeyChecking=no -t -i {0} {1}@{2} '
                '"{3}"').format(

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -102,8 +102,13 @@ def create(vm_):
     try:
         data = conn.deploy_node(**kwargs)
     except Exception as exc:
-        print('Linode returned the following error: {0}'.format(exc.message))
-        return
+        err = ('Error creating {0} on LINODE\n\n'
+               'The following exception was thrown by libcloud when trying to '
+               'run the initial deployment: \n{1}').format(
+                       vm_['name'], exc.message
+                       )
+        sys.stderr.write(err)
+        return False
     print('Created Cloud VM {0} with the following values:'.format(
         vm_['name']
         ))

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -77,8 +77,13 @@ def create(vm_):
     try:
         data = conn.deploy_node(**kwargs)
     except DeploymentError as exc:
-        print('Libcloud failed to connect to the new vm: {0}'.format(exc))
-        return
+        err = ('Error creating {0} on RACKSPACE\n\n'
+               'The following exception was thrown by libcloud when trying to '
+               'run the initial deployment: \n{1}').format(
+                       vm_['name'], exc
+                       )
+        sys.stderr.write(err)
+        return False
     print('Created Cloud VM {0} with the following values:'.format(
         vm_['name']
         ))


### PR DESCRIPTION
AWS already had proper error handling, but an inappropriate error message. The other cloud providers had messages added already, but they weren't as well done. This commit changes the errors to go to STDERR instead of STDOUT, and gives a more consistent error across all providers.
