### PR TITLE
EC2 profile and security group updates

### DIFF
--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -102,14 +102,14 @@ def keyname(vm_):
     '''
     Return the keyname
     '''
-    return str(vm_.get('AWS.keyname', __opts__.get('AWS.keyname', '')))
+    return str(vm_.get('keyname', __opts__.get('AWS.keyname', '')))
 
 
 def securitygroup(vm_):
     '''
     Return the security group
     '''
-    return str(vm_.get('AWS.securitygroup', __opts__.get('AWS.securitygroup', 'default')))
+    return str(vm_.get('securitygroup', __opts__.get('AWS.securitygroup', 'default')))
 
 
 def ssh_username(vm_):

--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -109,7 +109,7 @@ def securitygroup(vm_):
     '''
     Return the security group
     '''
-    return str(vm_.get('securitygroup', __opts__.get('AWS.securitygroup', 'default')))
+    return vm_.get('securitygroup', __opts__.get('AWS.securitygroup', 'default'))
 
 
 def ssh_username(vm_):


### PR DESCRIPTION
Two fixes:
- allow profiles to override core keyname & securitygroup props
- allow lists of security groups on EC2 instance
