### PR TITLE
Switch linode from using libcloud deploy to use salt-cloud wait_for_ssh

### DIFF
--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -17,6 +17,7 @@ the cloud configuration file
 # Import python libs
 import os
 import types
+import paramiko
 
 # Import libcloud
 from libcloud.compute.types import Provider
@@ -92,15 +93,15 @@ def create(vm_):
     '''
     print('Creating Cloud VM {0}'.format(vm_['name']))
     conn = get_conn()
+    deploy_script = script(vm_)
     kwargs = {}
     kwargs['name'] = vm_['name']
-    kwargs['deploy'] = script(vm_)
     kwargs['image'] = get_image(conn, vm_)
     kwargs['size'] = get_size(conn, vm_)
     kwargs['location'] = get_location(conn, vm_)
     kwargs['auth'] = NodeAuthPassword(get_password(vm_))
     try:
-        data = conn.deploy_node(**kwargs)
+        data = conn.create_node(**kwargs)
     except Exception as exc:
         err = ('Error creating {0} on LINODE\n\n'
                'The following exception was thrown by libcloud when trying to '
@@ -109,6 +110,14 @@ def create(vm_):
                        )
         sys.stderr.write(err)
         return False
+    if saltcloud.utils.wait_for_ssh(data.public_ips[0]):
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh.connect(data.public_ips[0], username='root', password=__opts__['LINODE.password'])
+        stdin, stdout, stderr = ssh.exec_command(deploy_script.script)
+    else:
+        print('Failed to start Salt on Cloud VM {0}'.format(vm_['name']))
+
     print('Created Cloud VM {0} with the following values:'.format(
         vm_['name']
         ))


### PR DESCRIPTION
libcloud's deploy isn't working so great, so we're switching to their create + our wait_for_ssh
