### PR TITLE
Switch rackspace from libcloud deploy to salt-cloud deploy

### DIFF
--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -86,10 +86,11 @@ def create(vm_):
         sys.stderr.write(err)
         return False
     if saltcloud.utils.wait_for_ssh(data.public_ips[0]):
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(data.public_ips[0], username='root', password=data.extra['password'])
-        stdin, stdout, stderr = ssh.exec_command(deploy_script.script)
+        if saltcloud.utils.wait_for_passwd(data.public_ips[0], username='root', password=data.extra['password']):
+            ssh = paramiko.SSHClient()
+            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            ssh.connect(data.public_ips[0], username='root', password=data.extra['password'])
+            stdin, stdout, stderr = ssh.exec_command(deploy_script.script)
     else:
         print('Failed to start Salt on Cloud VM {0}'.format(vm_['name']))
 

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -23,6 +23,7 @@ and requires that two configuration paramaters be set for use:
 # Import python libs
 import os
 import types
+import paramiko
 
 # Import libcloud 
 from libcloud.compute.types import Provider
@@ -69,13 +70,13 @@ def create(vm_):
     '''
     print('Creating Cloud VM {0}'.format(vm_['name']))
     conn = get_conn()
+    deploy_script = script(vm_)
     kwargs = {}
     kwargs['name'] = vm_['name']
-    kwargs['deploy'] = script(vm_)
     kwargs['image'] = get_image(conn, vm_)
     kwargs['size'] = get_size(conn, vm_)
     try:
-        data = conn.deploy_node(**kwargs)
+        data = conn.create_node(**kwargs)
     except DeploymentError as exc:
         err = ('Error creating {0} on RACKSPACE\n\n'
                'The following exception was thrown by libcloud when trying to '
@@ -84,6 +85,14 @@ def create(vm_):
                        )
         sys.stderr.write(err)
         return False
+    if saltcloud.utils.wait_for_ssh(data.public_ips[0]):
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh.connect(data.public_ips[0], username='root', password=data.extra['password'])
+        stdin, stdout, stderr = ssh.exec_command(deploy_script.script)
+    else:
+        print('Failed to start Salt on Cloud VM {0}'.format(vm_['name']))
+
     print('Created Cloud VM {0} with the following values:'.format(
         vm_['name']
         ))

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -9,6 +9,7 @@ import shutil
 import socket
 import tempfile
 import time
+import paramiko
 
 # Import salt libs
 import salt.crypt
@@ -131,6 +132,23 @@ def wait_for_ssh(host, port=22, timeout=900):
             return True
         except Exception:
             time.sleep(1)
+            if time.time() - start > timeout:
+                return False
+
+
+def wait_for_passwd(host, port=22, timeout=900, username='root', password=None):
+    '''
+    Wait until an ssh connection can be made on a specified host
+    '''
+    start = time.time()
+    while True:
+        try:
+            ssh = paramiko.SSHClient()
+            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            ssh.connect(data.public_ips[0], username=username, password=password)
+            return True
+        except Exception:
+            time.sleep(10)
             if time.time() - start > timeout:
                 return False
 

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -145,7 +145,7 @@ def wait_for_passwd(host, port=22, timeout=900, username='root', password=None):
         try:
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            ssh.connect(data.public_ips[0], username=username, password=password)
+            ssh.connect(hostname=host, port=22, username=username, password=password, timeout=20)
             return True
         except Exception:
             time.sleep(10)


### PR DESCRIPTION
This series of commits successfully switches rackspace from a libcloud deploy, to using our own in-house methods. This is a big step towards implementing our own standard deploy method.
