### PR TITLE
Turn deploy_script into a saltcloud.utils function

### DIFF
--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -88,11 +88,13 @@ def create(vm_):
                        )
         sys.stderr.write(err)
         return False
-    if saltcloud.utils.wait_for_ssh(data.public_ips[0]):
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(data.public_ips[0], username='root', password=data.extra['password'])
-        stdin, stdout, stderr = ssh.exec_command(deploy_script.script)
+    deployed = saltcloud.utils.deploy_script(
+        host=data.public_ips[0],
+        username='root',
+        password=data.extra['password'],
+        script=deploy_script.script)
+    if deployed:
+        print('Salt installed on {0}'.format(vm_['name']))
     else:
         print('Failed to start Salt on Cloud VM {0}'.format(vm_['name']))
 

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -110,11 +110,13 @@ def create(vm_):
                        )
         sys.stderr.write(err)
         return False
-    if saltcloud.utils.wait_for_ssh(data.public_ips[0]):
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(data.public_ips[0], username='root', password=__opts__['LINODE.password'])
-        stdin, stdout, stderr = ssh.exec_command(deploy_script.script)
+    deployed = saltcloud.utils.deploy_script(
+        host=data.public_ips[0],
+        username='root',
+        password=__opts__['LINODE.password'],
+        script=deploy_script.script)
+    if deployed:
+        print('Salt installed on {0}'.format(vm_['name']))
     else:
         print('Failed to start Salt on Cloud VM {0}'.format(vm_['name']))
 

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -86,23 +86,13 @@ def create(vm_):
                        )
         sys.stderr.write(err)
         return False
-    if saltcloud.utils.wait_for_ssh(data.public_ips[0]):
-        if saltcloud.utils.wait_for_passwd(data.public_ips[0], username='root', password=data.extra['password']):
-            ssh = paramiko.SSHClient()
-            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            ssh.connect(data.public_ips[0], 22, username='root', password=data.extra['password'])
-            tmpfh, tmppath = tempfile.mkstemp()
-            tmpfile = open(tmppath, 'w')
-            tmpfile.write(deploy_script.script)
-            tmpfile.close()
-            sftp = ssh.get_transport()
-            sftp.open_session()
-            sftp = paramiko.SFTPClient.from_transport(sftp)
-            sftp.put(tmppath, '/tmp/deploy.sh')
-            os.remove(tmppath)
-            ssh.exec_command('chmod +x /tmp/deploy.sh')
-            ssh.exec_command('/tmp/deploy.sh')
-            ssh.exec_command('rm /tmp/deploy.sh')
+    deployed = saltcloud.utils.deploy_script(
+        host=data.public_ips[0],
+        username='root',
+        password=data.extra['password'],
+        script=deploy_script.script)
+    if deployed:
+        print('Salt installed on {0}'.format(vm_['name']))
     else:
         print('Failed to start Salt on Cloud VM {0}'.format(vm_['name']))
 


### PR DESCRIPTION
This will greatly simplify adding providers in the future.
