### PR TITLE
Do not use sudo if the user is already root

### DIFF
--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -212,11 +212,14 @@ def create(vm_):
                 username = user
                 break
         kwargs['ssh_username'] = username
+    deploy_command='sudo bash /tmp/deploy.sh'
+    if username == 'root':
+        deploy_command='/tmp/deploy.sh'
     deployed = saltcloud.utils.deploy_script(
         host=ip_address,
         username=username,
         key_filename=__opts__['AWS.private_key'],
-        deploy_command='sudo bash /tmp/deploy.sh',
+        deploy_command=deploy_command,
         tty=True,
         script=deploy_script.script)
     if deployed:

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -211,10 +211,11 @@ def deploy_script(host, port=22, timeout=900, username='root',
             if tty:
                 # Tried this with paramiko's invoke_shell(), and got tired of
                 # fighting with it
-                cmd = ('ssh -oStrictHostKeyChecking=no -t -i {0} {1}@{2} "sudo bash /tmp/deploy.sh"').format(
+                cmd = ('ssh -oStrictHostKeyChecking=no -t -i {0} {1}@{2} "{3}"').format(
                         key_filename,
                         username,
-                        host
+                        host,
+                        deploy_command
                         )
                 subprocess.call(cmd, shell=True)
             else:


### PR DESCRIPTION
This wan't a problem until we started encountering distros (like FreeBSD) that didn't have sudo installed by default.

Also fixes a related issue with the ssh command not using the deploy_command that was passed in.
