### PR TITLE
Add event-reactive initialization for #59

### DIFF
--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -221,7 +221,9 @@ def create(vm_):
         key_filename=__opts__['AWS.private_key'],
         deploy_command=deploy_command,
         tty=True,
-        script=deploy_script.script)
+        script=deploy_script.script,
+        name=vm_['name'],
+        sock_dir=__opts__['sock_dir'])
     if deployed:
         print('Salt installed on {0}'.format(vm_['name']))
     else:

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -92,7 +92,9 @@ def create(vm_):
         host=data.public_ips[0],
         username='root',
         password=data.extra['password'],
-        script=deploy_script.script)
+        script=deploy_script.script,
+        name=vm_['name'],
+        sock_dir=__opts__['sock_dir'])
     if deployed:
         print('Salt installed on {0}'.format(vm_['name']))
     else:

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -114,7 +114,9 @@ def create(vm_):
         host=data.public_ips[0],
         username='root',
         password=__opts__['LINODE.password'],
-        script=deploy_script.script)
+        script=deploy_script.script,
+        name=vm_['name'],
+        sock_dir=__opts__['sock_dir'])
     if deployed:
         print('Salt installed on {0}'.format(vm_['name']))
     else:

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -90,7 +90,9 @@ def create(vm_):
         host=data.public_ips[0],
         username='root',
         password=data.extra['password'],
-        script=deploy_script.script)
+        script=deploy_script.script,
+        name=vm_['name'],
+        sock_dir=__opts__['sock_dir'])
     if deployed:
         print('Salt installed on {0}'.format(vm_['name']))
     else:


### PR DESCRIPTION
This commit starts to address using event-reactive initialization. It does have the ability to wait for an event stating that the machine has checked in with the master, but at this point it doesn't actually do anything else. This will be addressed in another pull.

This commit also adds support for all current cloud providers, except for joyent, who doesn't use the same deploy function just yet.
