### PR TITLE
Add remove_key functionality (issue #78)

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -129,7 +129,8 @@ class Cloud(object):
         for prov, names_ in dels.items():
             fun = '{0}.destroy'.format(prov)
             for name in names_:
-            	self.clouds[fun](name)
+                if self.clouds[fun](name):
+                    saltcloud.utils.remove_key(self.opts['pki_dir'], name)
 
     def create(self, vm_):
         '''

--- a/saltcloud/libcloudfuncs.py
+++ b/saltcloud/libcloudfuncs.py
@@ -136,9 +136,10 @@ def destroy(name):
     ret = conn.destroy_node(node)
     if ret:
         print('Destroyed VM: {0}'.format(name))
+        return True
     else:
         print('Failed to Destroy VM: {0}'.format(name))
-
+        return False
 
 def list_nodes():
     '''

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -89,6 +89,15 @@ def accept_key(pki_dir, pub, id_):
     with open(key, 'w+') as fp_:
         fp_.write(pub)
 
+def remove_key(pki_dir, id_):
+    '''
+    This method removes a specified key from the accepted keys dir
+    '''
+    key = os.path.join(
+            pki_dir,
+            'minions/{0}'.format(id_)
+            )
+    os.remove(key)
 
 def get_option(option, opts, vm_):
     '''


### PR DESCRIPTION
As it says. Currently only used with salt-cloud -d.
