### PR TITLE
Changes to the Ubuntu deploy scripts

### DIFF
--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -176,6 +176,9 @@ def create(vm_):
     elif 'password' in data.extra:
 	deployargs['password'] = data.extra['password']
 
+    if 'sudo' in vm_:
+        deployargs['sudo'] = vm_['sudo']
+
     print('Running deploy script')
     deployed = saltcloud.utils.deploy_script(**deployargs)
     if deployed:

--- a/saltcloud/deploy/Ubuntu-git.sh
+++ b/saltcloud/deploy/Ubuntu-git.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sudo bash
+#!/bin/bash
 
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem

--- a/saltcloud/deploy/Ubuntu-git.sh
+++ b/saltcloud/deploy/Ubuntu-git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/sudo bash
 
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem

--- a/saltcloud/deploy/Ubuntu.sh
+++ b/saltcloud/deploy/Ubuntu.sh
@@ -10,3 +10,4 @@ apt-get install -y python-software-properties
 echo | add-apt-repository  ppa:saltstack/salt
 apt-get update
 apt-get install -y salt-minion
+service salt-minion start

--- a/saltcloud/deploy/Ubuntu.sh
+++ b/saltcloud/deploy/Ubuntu.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sudo bash
+#!/bin/bash
 
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem

--- a/saltcloud/deploy/Ubuntu.sh
+++ b/saltcloud/deploy/Ubuntu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/sudo bash
 
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -206,7 +206,7 @@ def wait_for_passwd(host, port=22, timeout=900, username='root',
 
 def deploy_script(host, port=22, timeout=900, username='root',
                   password=None, key_filename=None, script=None,
-                  deploy_command='bash /tmp/deploy.sh', tty=None,
+                  deploy_command='/tmp/deploy.sh', sudo=False, tty=None,
                   name=None, pub_key=None, sock_dir=None):
     '''
     Copy a deploy script to a remote server, execute it, and remove it
@@ -240,6 +240,9 @@ def deploy_script(host, port=22, timeout=900, username='root',
             sftp.put(tmppath, '/tmp/deploy.sh')
             os.remove(tmppath)
             ssh.exec_command('chmod +x /tmp/deploy.sh')
+
+            if sudo:
+                deploy_command = 'sudo ' + deploy_command
 
             newtimeout = timeout - (time.mktime(time.localtime()) - starttime)
             queue = multiprocessing.Queue()

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -206,7 +206,7 @@ def wait_for_passwd(host, port=22, timeout=900, username='root',
 
 def deploy_script(host, port=22, timeout=900, username='root',
                   password=None, key_filename=None, script=None,
-                  deploy_command='/tmp/deploy.sh', tty=None,
+                  deploy_command='bash /tmp/deploy.sh', tty=None,
                   name=None, pub_key=None, sock_dir=None):
     '''
     Copy a deploy script to a remote server, execute it, and remove it

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -206,7 +206,7 @@ def wait_for_passwd(host, port=22, timeout=900, username='root',
 
 def deploy_script(host, port=22, timeout=900, username='root',
                   password=None, key_filename=None, script=None,
-                  deploy_command='bash /tmp/deploy.sh', tty=None,
+                  deploy_command='/tmp/deploy.sh', tty=None,
                   name=None, pub_key=None, sock_dir=None):
     '''
     Copy a deploy script to a remote server, execute it, and remove it


### PR DESCRIPTION
This changes the shell for the Ubuntu deploy scripts from `bash` to `sudo bash`, and also starts the salt-minion service once it is installed.
