### PR TITLE
fixed bug in config for EC2 availability zones

### DIFF
--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -157,8 +157,8 @@ def get_availability_zone(conn, vm_):
     az = None
     if 'availability_zone' in vm_:
         az = vm_['availability_zone']
-    elif 'EC2.availability_zone' in __opts__:
-        az = __opts__['EC2.availability_zone']
+    elif 'AWS.availability_zone' in __opts__:
+        az = __opts__['AWS.availability_zone']
 
     if az is None:
         # Default to first zone


### PR DESCRIPTION
Fixed a bug left over from when the term "EC2" was swapped to "AWS".
