### PR TITLE
Change salt-cloud to use the new outputter system (in 0.10.5)

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -208,29 +208,16 @@ class SaltCloud(object):
         mapper = saltcloud.cloud.Map(self.opts)
 
         if self.opts['query'] or self.opts['full_query']:
-            get_outputter = salt.output.get_outputter
-            if self.opts['raw_out']:
-                printout = get_outputter('raw')
-            elif self.opts['json_out']:
-                printout = get_outputter('json')
-            elif self.opts['txt_out']:
-                printout = get_outputter('txt')
-            elif self.opts['yaml_out']:
-                printout = get_outputter('yaml')
-            else:
-                printout = get_outputter(None)
-
             query = 'list_nodes'
             if self.opts['full_query']:
                 query = 'list_nodes_full'
 
-            color = not bool(self.opts['no_color'])
             query_map = {}
             if self.opts['map']:
                 query_map = mapper.interpolated_map(query=query)
             else:
                 query_map = mapper.map_providers(query=query)
-            printout(query_map, color=color)
+            salt.output.display_output(query_map, '', self.opts)
 
         if self.opts['version']:
             print VERSION

--- a/saltcloud/loader.py
+++ b/saltcloud/loader.py
@@ -8,11 +8,9 @@ import os
 import salt.loader
 import saltcloud
 
-salt.loader.salt_base_path = os.path.dirname(saltcloud.__file__)
-
 def clouds(opts):
     '''
     Return the cloud functions
     '''
-    load = salt.loader._create_loader(opts, 'clouds', 'cloud')
+    load = salt.loader._create_loader(opts, 'clouds', 'cloud', base_path=os.path.dirname(saltcloud.__file__))
     return load.gen_functions()


### PR DESCRIPTION
This means the new salt-cloud cannot be released until salt 0.10.5 drops.
