### PR TITLE
wait_for_passwd logic fix

### DIFF
--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -213,12 +213,10 @@ def create(vm_):
     else:
         ip_address = data.public_ips[0]
     if saltcloud.utils.wait_for_ssh(ip_address):
-        username = 'ec2-user'
         for user in usernames:
             if saltcloud.utils.wait_for_passwd(host=ip_address, username=user, timeout=60, key_filename=__opts__['AWS.private_key']):
                 username = user
                 break
-        kwargs['ssh_username'] = username
     deploy_command='bash /tmp/deploy.sh'
     if username == 'root':
         deploy_command='/tmp/deploy.sh'

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -178,7 +178,7 @@ def wait_for_passwd(host, port=22, timeout=900, username='root',
     '''
     trycount=0
     while trycount < maxtries:
-        tryconnect = None
+        connectfail = False
         try:
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -191,8 +191,9 @@ def wait_for_passwd(host, port=22, timeout=900, username='root',
             if key_filename:
                 kwargs['key_filename'] = key_filename
             try:
-                tryconnect = ssh.connect(**kwargs)
+                ssh.connect(**kwargs)
             except (paramiko.AuthenticationException, paramiko.SSHException) as authexc:
+                connectfail = True
                 ssh.close()
                 trycount += 1
                 print('Attempting to authenticate (try {0} of {1}): {2}'.format(trycount, maxtries, authexc))
@@ -207,7 +208,7 @@ def wait_for_passwd(host, port=22, timeout=900, username='root',
             except Exception as exc:
                 print('There was an error in wait_for_passwd: {0}'.format(exc))
                 log.error('There was an error in wait_for_passwd: {0}'.format(exc))
-            if tryconnect:
+            if connectfail == False:
                 return True
             return False
         except Exception:


### PR DESCRIPTION
The paramiko.SSHClient connect() method doesn't actually return a boolean, causing my deploy to always fail:

http://www.lag.net/paramiko/docs/paramiko.client-pysrc.html

I'm not entirely sure how anything could deploy correctly with the code as it was - and as I recall most testing doesn't happen against EC2.

Could this fix be tested to ensure it doesn't break for other providers?
