### PR TITLE
Don't force a name for openstack compute endpoint

### DIFF
--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -83,8 +83,10 @@ def get_conn():
     authinfo = {
             'ex_force_auth_url': __opts__['OPENSTACK.identity_url'],
             'ex_force_auth_version': '2.0_password',
-            'ex_force_service_name': 'Compute',
     }
+
+    if 'OPENSTACK.compute_name' in __opts__:
+        authinfo['ex_force_service_name'] = __opts__['OPENSTACK.compute_name']
 
     if 'OPENSTACK.compute_region' in __opts__:
         authinfo['ex_force_service_region'] = __opts__['OPENSTACK.compute_region']


### PR DESCRIPTION
This is optional and there should be a configuration option for it if we're about to force it.
