### PR TITLE
Adding the ability to perform extra actions

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,8 +10,8 @@ Salt into cloud providers in a clean way so that minions on public cloud
 systems can be quickly and easily modeled and provisioned.
 
 Salt cloud allows for cloud based minions to be managed via virtual machine
-maps and profiles. This means that individual cloud vms can be created, or
-large groups of cloud vms can be created at once or managed.
+maps and profiles. This means that individual cloud VMs can be created, or
+large groups of cloud VMs can be created at once or managed.
 
 Virtual machines created with Salt cloud install salt on the target virtual
 machine and assign it to the specified master. This means that virtual
@@ -39,12 +39,17 @@ cloud providers.
 Using Salt Cloud
 ================
 
-Salt cloud works via profiles and maps. Simple profiles for cloud vms are
+Salt cloud works via profiles and maps. Simple profiles for cloud VMs are
 defined and can be used directly, or a map can be defined specifying
 a large group of virtual machines to create.
 
 * :doc:`Profiles <topics/profiles>`
 * :doc:`Maps <topics/map>`
+
+Once a VM has been deployed, a number of actions may be available to perform
+on it, depending on the specific cloud provider.
+
+* :doc:`Actions <topics/action>`
 
 Extending Salt Cloud
 ====================

--- a/doc/topics/action.rst
+++ b/doc/topics/action.rst
@@ -25,6 +25,9 @@ The following is a list of actions currently supported by salt-cloud:
 
     all providers:
         - reboot
+    aws:
+        - start
+        - stop
     joyent:
         - stop
 

--- a/doc/topics/action.rst
+++ b/doc/topics/action.rst
@@ -1,0 +1,30 @@
+=============
+Cloud Actions
+=============
+
+Once a VM has been created, there are a number of actions that can be performed
+on it. The "reboot" action can be used across all providers, but all other
+actions are specific to the cloud provider. In order to perform an action, you
+may specify it from the command line, including the name(s) of the VM to
+perform the action on:
+
+.. code-block:: bash
+
+    $ salt-cloud -a reboot vm_name
+    $ salt-cloud -a reboot vm1 vm2 vm2
+
+Or you may specify a map which includes all VMs to perform the action on:
+
+.. code-block:: bash
+
+    $ salt-cloud -a reboot -m /path/to/mapfile
+
+The following is a list of actions currently supported by salt-cloud:
+
+.. code-block:: yaml
+
+    all providers:
+        - reboot
+    joyent:
+        - stop
+

--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -82,6 +82,15 @@ class SaltCloud(parsers.SaltCloudParser):
             mapper.destroy(names)
             self.exit(0)
 
+        if self.options.action and (self.config.get('names', None) or
+                                     self.options.map):
+            if self.options.map:
+                names = mapper.delete_map(query='list_nodes')
+            else:
+                names = self.config.get('names', None)
+            mapper.do_action(names)
+            self.exit(0)
+
         if self.options.profile and self.config.get('names', False):
             mapper.run_profile()
             self.exit(0)

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -156,6 +156,22 @@ class Cloud(object):
                 if self.clouds[fun](name):
                     saltcloud.utils.remove_key(self.opts['pki_dir'], name)
 
+    def reboot(self, names):
+        '''
+        Reboot the named vms
+        '''
+        pmap = self.map_providers()
+        acts = {}
+        for prov, nodes in pmap.items():
+            acts[prov] = []
+            for node in nodes:
+                if node in names:
+                    acts[prov].append(node)
+        for prov, names_ in acts.items():
+            fun = '{0}.reboot'.format(prov)
+            for name in names_:
+                self.clouds[fun](name)
+
     def create(self, vm_):
         '''
         Create a single vm
@@ -223,6 +239,22 @@ class Cloud(object):
                         self.create(vm_)
         if not found:
             log.error('Profile {0} is not defined'.format(self.opts['profile']))
+
+    def do_action(self, names):
+        '''
+        Perform an action which may be specific to this cloud provider
+        '''
+        pmap = self.map_providers()
+        acts = {}
+        for prov, nodes in pmap.items():
+            acts[prov] = []
+            for node in nodes:
+                if node in names:
+                    acts[prov].append(node)
+        for prov, names_ in acts.items():
+            fun = '{0}.{1}'.format(prov, self.opts['action'])
+            for name in names_:
+                self.clouds[fun](name)
 
 
 class Map(Cloud):

--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -259,3 +259,34 @@ def create_attach_volumes(volumes, location, data):
         attach = conn.attach_volume(data, created_volume, volume['device'])
         if attach:
             log.info('{0} attached to {1} (aka {2}) as device {3}'.format(created_volume.id, data.id, data.name, volume['device']))
+
+
+def stop(name):
+    '''
+    Stop a node
+    '''
+    conn = get_conn()
+    node = get_node(conn, name)
+    try:
+        data = conn.ex_stop_node(node=node)
+        log.debug(data)
+        log.info('Stopped node {0}'.format(name))
+    except Exception as exc:
+        log.error('Failed to stop node {0}'.format(name))
+        log.error(exc)
+
+
+def start(name):
+    '''
+    Start a node
+    '''
+    conn = get_conn()
+    node = get_node(conn, name)
+    try:
+        data = conn.ex_start_node(node=node)
+        log.debug(data)
+        log.info('Started node {0}'.format(name))
+    except Exception as exc:
+        log.error('Failed to start node {0}'.format(name))
+        log.error(exc)
+

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -118,7 +118,7 @@ def create(vm_):
 
 def stop(name):
     '''
-    Stop a node on Joyent
+    Stop a node
     '''
     conn = get_conn()
     node = get_node(conn, name)

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -45,6 +45,7 @@ avail_images = types.FunctionType(avail_images.__code__, globals())
 avail_sizes = types.FunctionType(avail_sizes.__code__, globals())
 script = types.FunctionType(script.__code__, globals())
 destroy = types.FunctionType(destroy.__code__, globals())
+reboot = types.FunctionType(reboot.__code__, globals())
 list_nodes = types.FunctionType(list_nodes.__code__, globals())
 list_nodes_full = types.FunctionType(list_nodes_full.__code__, globals())
 list_nodes_select = types.FunctionType(list_nodes_select.__code__, globals())
@@ -113,3 +114,19 @@ def create(vm_):
     log.info('Created Cloud VM {0} with the following values:'.format(vm_['name']))
     for key, val in data.__dict__.items():
         log.info('  {0}: {1}'.format(key, val))
+
+
+def stop(name):
+    '''
+    Stop a node on Joyent
+    '''
+    conn = get_conn()
+    node = get_node(conn, name)
+    try:
+        data = conn.ex_stop_node(node=node)
+        log.debug(data)
+        log.info('Stopped node {0}'.format(name))
+    except Exception as exc:
+        log.error('Failed to stop node {0}'.format(name))
+        log.error(exc)
+

--- a/saltcloud/libcloudfuncs.py
+++ b/saltcloud/libcloudfuncs.py
@@ -212,6 +212,30 @@ def destroy(name):
         return False
 
 
+def reboot(name):
+    '''
+    Reboot a single vm
+    '''
+    conn = get_conn()
+    node = get_node(conn, name)
+    if node is None:
+        log.error('Unable to find the VM {0}'.format(name))
+    log.info('Rebooting VM: {0}'.format(name))
+    ret = conn.reboot_node(node)
+    if ret:
+        log.info('Rebooted VM: {0}'.format(name))
+        # Fire reboot action
+        event = salt.utils.event.SaltEvent(
+            'master',
+            __opts__['sock_dir']
+            )
+        event.fire_event('{0} has been rebooted'.format(name), 'salt-cloud')
+        return True
+    else:
+        log.error('Failed to reboot VM: {0}'.format(name))
+        return False
+
+
 def list_nodes():
     '''
     Return a list of the vms that are on the provider

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -152,6 +152,12 @@ class ExecutionOptionsMixIn(object):
             # Include description here as a string
         )
         group.add_option(
+            '-a', '--action',
+            default='',
+            help=('Perform an action that may be specific to this cloud'
+                  'provider')
+        )
+        group.add_option(
             '-p', '--profile',
             default='',
             help='Specify a profile to use for the vms'


### PR DESCRIPTION
Add the ability to perform a provider-specific action using -a or --action:

salt-cloud -a function vm_name [vm2_name...]

It will take time to fill in all actions for all supported cloud providers, but this adds reboot for everyone, and stop for Joyent. All other actions will be submitted in other pull reqs, as they are written.
