### PR TITLE
AWS Sydney region support. Requires patch for https://issues.apache.org/...

### DIFF
--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -76,6 +76,7 @@ def __virtual__():
 EC2_LOCATIONS = {
     'ap-northeast-1': Provider.EC2_AP_NORTHEAST,
     'ap-southeast-1': Provider.EC2_AP_SOUTHEAST,
+    'ap-southeast-2': Provider.EC2_AP_SOUTHEAST2,
     'eu-west-1': Provider.EC2_EU_WEST,
     'sa-east-1': Provider.EC2_SA_EAST,
     'us-east-1': Provider.EC2_US_EAST,


### PR DESCRIPTION
Here's a patch that enables support for the new AWS region in Sydney (ap-southeast-2).

http://aws.typepad.com/aws/2012/11/asia-pacific-sydney-region-open.html

It requires the patch for this libcloud bug I filed, requesting AWS Sydney support. I believe this is currently only in trunk, not in a release.

https://issues.apache.org/jira/browse/LIBCLOUD-264

https://github.com/lexual/salt-cloud/commit/c1c5189b7ec420d62764fed80bf054ece87a4fa4
