### PR TITLE
Test for EC2_AP_SOUTHEAST2 attribute before adding it to the locations dictionary.

### DIFF
--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -76,7 +76,6 @@ def __virtual__():
 EC2_LOCATIONS = {
     'ap-northeast-1': Provider.EC2_AP_NORTHEAST,
     'ap-southeast-1': Provider.EC2_AP_SOUTHEAST,
-    'ap-southeast-2': Provider.EC2_AP_SOUTHEAST2,
     'eu-west-1': Provider.EC2_EU_WEST,
     'sa-east-1': Provider.EC2_SA_EAST,
     'us-east-1': Provider.EC2_US_EAST,
@@ -84,6 +83,9 @@ EC2_LOCATIONS = {
     'us-west-2': Provider.EC2_US_WEST_OREGON
 }
 DEFAULT_LOCATION = 'us-east-1'
+
+if hasattr(Provider, 'EC2_AP_SOUTHEAST2'):
+    EC2_LOCATIONS['ap-southeast-2'] = Provider.EC2_AP_SOUTHEAST2
 
 
 def get_conn(**kwargs):


### PR DESCRIPTION
Test for EC2_AP_SOUTHEAST2 attribute before adding it to the locations dictionary.
