### PR TITLE
Beginning steps towards new salt-cloud configuration

### DIFF
--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -56,12 +56,13 @@ def __virtual__():
     Set up the libcloud functions and check for GOGRID configs
     '''
     confs = [
-            'GOGRID.apikey',
-            'GOGRID.sharedsecret',
+            'apikey',
+            'sharedsecret',
             ]
     for conf in confs:
-        if conf not in __opts__:
-            return False
+        for provider in __opts__['providers']['gogrid']:
+            if conf not in __opts__['providers']['gogrid'][provider]:
+                return False
     log.debug('Loading GoGrid cloud module')
     return 'gogrid'
 

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -53,17 +53,22 @@ list_nodes_select = types.FunctionType(list_nodes_select.__code__, globals())
 # Only load in this module is the GOGRID configurations are in place
 def __virtual__():
     '''
-    Set up the libcloud funcstions and check for RACKSPACE configs
+    Set up the libcloud functions and check for GOGRID configs
     '''
-    if 'GOGRID.apikey' in __opts__ and 'GOGRID.sharedsecret' in __opts__:
-        log.debug('Loading GoGrid cloud module')
-        return 'gogrid'
-    return False
+    confs = [
+            'GOGRID.apikey',
+            'GOGRID.sharedsecret',
+            ]
+    for conf in confs:
+        if conf not in __opts__:
+            return False
+    log.debug('Loading GoGrid cloud module')
+    return 'gogrid'
 
 
 def get_conn():
     '''
-    Return a conn object for the passed vm data
+    Return a conn object for the passed VM data
     '''
     driver = get_driver(Provider.GOGRID)
     return driver(
@@ -74,7 +79,7 @@ def get_conn():
 
 def create(vm_):
     '''
-    Create a single vm from a data dict
+    Create a single VM from a data dict
     '''
     log.info('Creating Cloud VM {0}'.format(vm_['name']))
     conn = get_conn()

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -41,6 +41,7 @@ def cloud_config(path):
         opts = salt.config.include_config(opts, path)
 
     opts = old_to_new(opts)
+    opts = prov_dict(opts)
 
     return opts
 
@@ -61,6 +62,28 @@ def old_to_new(opts):
                     opts[provider.lower()] = {}
                 comps = opt.split('.')
                 opts[provider.lower()][comps[1]] = opts[opt]
+    return opts
+
+
+def prov_dict(opts):
+    providers = ('AWS',
+                 'GOGRID',
+                 'IBMSCE',
+                 'JOYENT',
+                 'LINODE',
+                 'OPENSTACK',
+                 'RACKSPACE')
+    optskeys = opts.keys()
+    opts['providers'] = {}
+    for provider in providers:
+        lprov = provider.lower()
+        opts['providers'][lprov] = {}
+        for opt in optskeys:
+            if opt == lprov:
+                opts['providers'][lprov][lprov] = opts[opt]
+            elif type(opts[opt]) is dict and 'provider' in opts[opt]:
+                if opts[opt]['provider'] == lprov:
+                    opts['providers'][lprov][opt] = opts[opt]
     return opts
 
 

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -46,8 +46,6 @@ def cloud_config(path):
 
 
 def old_to_new(opts):
-    import pprint
-    import sys
     optskeys = opts.keys()
     providers = ('AWS',
                  'GOGRID',
@@ -63,7 +61,6 @@ def old_to_new(opts):
                     opts[provider.lower()] = {}
                 comps = opt.split('.')
                 opts[provider.lower()][comps[1]] = opts[opt]
-                pprint.pprint(opts)
     return opts
 
 

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -40,6 +40,30 @@ def cloud_config(path):
     if 'include' in opts:
         opts = salt.config.include_config(opts, path)
 
+    opts = old_to_new(opts)
+
+    return opts
+
+
+def old_to_new(opts):
+    import pprint
+    import sys
+    optskeys = opts.keys()
+    providers = ('AWS',
+                 'GOGRID',
+                 'IBMSCE',
+                 'JOYENT',
+                 'LINODE',
+                 'OPENSTACK',
+                 'RACKSPACE')
+    for opt in optskeys:
+        for provider in providers:
+            if opt.startswith(provider):
+                if provider.lower() not in opts:
+                    opts[provider.lower()] = {}
+                comps = opt.split('.')
+                opts[provider.lower()][comps[1]] = opts[opt]
+                pprint.pprint(opts)
     return opts
 
 


### PR DESCRIPTION
These commits shouldn't affect current functionality, but are the first steps towards converting salt-cloud over to a new configuration file format. Using these commits, old conf files will still work in salt-cloud, at least for the time being. New-style conf files (which as as-yet undocumented, but easy to figure out from the code) are not yet supported.

GoGrid is my first test subject. Old-style configuration is still required, but after salt-cloud converts old to new internally, the GoGrid module checks in **virtual** to see if any gogrid providers are defined... but technically only one will be used at the moment.
