### PR TITLE
Passing "None" argument to quiet down weird error

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -110,7 +110,7 @@ class Cloud(object):
                 # The capability to gather images is not supported by this
                 # cloud module
                 continue
-            images[prov] = self.clouds[fun]()
+            images[prov] = self.clouds[fun](None)
         return images
 
     def size_list(self, lookup='all'):
@@ -129,7 +129,7 @@ class Cloud(object):
                 # The capability to gather sizes is not supported by this
                 # cloud module
                 continue
-            sizes[prov] = self.clouds[fun]()
+            sizes[prov] = self.clouds[fun](None)
         return sizes
 
     def create_all(self):


### PR DESCRIPTION
This started happening because of pull req #179:

Traceback (most recent call last):
  File "/usr/bin/salt-cloud", line 14, in <module>
    main()
  File "/usr/bin/salt-cloud", line 10, in main
    cloud.run()
  File "/usr/lib/python2.7/site-packages/saltcloud/cli.py", line 72, in run
    mapper.size_list(self.options.list_sizes)
  File "/usr/lib/python2.7/site-packages/saltcloud/cloud.py", line 132, in size_list
    sizes[prov] = self.clouds[fun]()
TypeError: avail_sizes() takes exactly 1 argument (0 given)

The weird thing is, avail_sizes() calls for conn=None, which shouldn't make it required. But passing in None seems to fix it, at least for the moment.
