### PR TITLE
Report syntax errors in map file. Exit when nothing to do for a map.

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -122,6 +122,9 @@ class SaltCloud(parsers.SaltCloudParser):
             self.exit(0)
 
         if self.options.map and self.selected_query_option is None:
+            if len(mapper.map) == 0:
+                print('Nothing to do')
+                self.exit(0)
             try:
                 mapper.run_map()
             except Exception as exc:

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -303,7 +303,9 @@ class Map(Cloud):
         try:
             with open(self.opts['map'], 'rb') as fp_:
                 map_ = yaml.load(fp_.read())
-        except Exception:
+        except Exception as exc:
+            log.error('Rendering map {0} failed, render error:\n{1}'
+                      .format(self.opts['map'], exc))
             return {}
         if 'include' in map_:
             map_ = salt.config.include_config(map_, self.opts['map'])


### PR DESCRIPTION
As described, just a couple of small fixes relating to map files.

You may well want to change the "Nothing to do" message!
