### PR TITLE
noinput on ubuntu install, keep user's config

### DIFF
--- a/saltcloud/deploy/Ubuntu-git.sh
+++ b/saltcloud/deploy/Ubuntu-git.sh
@@ -9,7 +9,7 @@ echo deb http://ppa.launchpad.net/saltstack/salt/ubuntu `lsb_release -sc` main |
 wget -q -O- "http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0x4759FA960E27C0A6" | apt-key add -
 apt-get update
 
-apt-get install -y salt-minion git-core
+apt-get install -y -o DPkg::Options::=--force-confold salt-minion git-core
 # minion will be started automatically by install
 service salt-minion stop
 

--- a/saltcloud/deploy/Ubuntu.sh
+++ b/saltcloud/deploy/Ubuntu.sh
@@ -9,5 +9,5 @@ echo deb http://ppa.launchpad.net/saltstack/salt/ubuntu `lsb_release -sc` main |
 wget -q -O- "http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0x4759FA960E27C0A6" | apt-key add -
 apt-get update
 
-apt-get install -y salt-minion
+apt-get install -y -o DPkg::Options::=--force-confold salt-minion
 # minion will be started automatically by install


### PR DESCRIPTION
UNTESTED Quick fix for saltstack/salt-cloud#230

Should work until bootstrap script gets integrated in 8.4
