### PR TITLE
Force portsnap to run non-interactively without a foolishly-long wait

### DIFF
--- a/saltcloud/deploy/FreeBSD.sh
+++ b/saltcloud/deploy/FreeBSD.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-portsnap fetch extract update
+sed -i 's/jot -r 1 0 3600/jot -r 1 0 3/' /usr/sbin/portsnap
+portsnap cron extract update
+sed -i 's/jot -r 1 0 3/jot -r 1 0 3600/' /usr/sbin/portsnap
 cd /usr/ports/ports-mgmt/pkg
 make install clean
 cd


### PR DESCRIPTION
Forcing FreeBSD into submission.

Resolves issue #69.
