### PR TITLE
Make bootstrap-salt-minion the default deploy script

### DIFF
--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -105,14 +105,20 @@ def create(vm_):
         log.error(err)
         return False
     if __opts__['deploy'] is True:
-        deployed = saltcloud.utils.deploy_script(
-            host=data.public_ips[0],
-            username='root',
-            password=data.extra['password'],
-            script=deploy_script.script,
-            name=vm_['name'],
-            start_action=__opts__['start_action'],
-            sock_dir=__opts__['sock_dir'])
+        deploy_kwargs = {
+            'host': data.public_ips[0],
+            'username': 'root',
+            'password': data.extra['password'],
+            'script': deploy_script.script,
+            'name': vm_['name'],
+            'start_action': __opts__['start_action'],
+            'sock_dir': __opts__['sock_dir'],
+            'conf_file': __opts__['conf_file'],
+            'minion_pem': vm_['priv_key'],
+            'minion_pub': vm_['pub_key'],
+            }
+        deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
+        deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
         else:

--- a/saltcloud/clouds/ibmsce.py
+++ b/saltcloud/clouds/ibmsce.py
@@ -132,16 +132,23 @@ def create(vm_):
 
     if __opts__['deploy'] is True:
         log.debug('Deploying {0} using IP address {1}'.format(vm_['name'], data.public_ips[0]))
-        deployed = saltcloud.utils.deploy_script(
-            host=data.public_ips[0],
-            username='idcuser',
-            key_filename=__opts__['IBMSCE.ssh_key_file'],
-            script=deploy_script.script,
-            name=vm_['name'],
-            provider='ibmsce',
-            sudo=True,
-            start_action=__opts__['start_action'],
-            sock_dir=__opts__['sock_dir'])
+        deploy_kwargs = {
+            'host': data.public_ips[0],
+            'username': 'idcuser',
+            'provider': 'ibmsce',
+            'password': data.extra['password'],
+            'key_filename': __opts__['IBMSCE.ssh_key_file'],
+            'script': deploy_script.script,
+            'name': vm_['name'],
+            'sudo': True,
+            'start_action': __opts__['start_action'],
+            'sock_dir': __opts__['sock_dir'],
+            'conf_file': __opts__['conf_file'],
+            'minion_pem': vm_['priv_key'],
+            'minion_pub': vm_['pub_key'],
+            }
+        deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
+        deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
         else:

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -97,17 +97,22 @@ def create(vm_):
         log.error(err)
         return False
     if __opts__['deploy'] is True:
-        deployed = saltcloud.utils.deploy_script(
-            host=data.public_ips[0],
-            username='root',
-            key_filename=__opts__['JOYENT.private_key'],
-            deploy_command='/tmp/deploy.sh',
-            tty=True,
-            script=deploy_script.script,
-            name=vm_['name'],
-            start_action=__opts__['start_action'],
-            conf_file=__opts__['conf_file'],
-            sock_dir=__opts__['sock_dir'])
+        deploy_kwargs = {
+            'host': data.public_ips[0],
+            'username': 'root',
+            'key_filename': __opts__['JOYENT.private_key'],
+            'script': deploy_script.script,
+            'name': vm_['name'],
+            'deploy_command': '/tmp/deploy.sh',
+            'tty': True,
+            'start_action': __opts__['start_action'],
+            'sock_dir': __opts__['sock_dir'],
+            'conf_file': __opts__['conf_file'],
+            'minion_pem': vm_['priv_key'],
+            'minion_pub': vm_['pub_key'],
+            }
+        deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
+        deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
         else:

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -124,14 +124,21 @@ def create(vm_):
         return False
 
     if __opts__['deploy'] is True:
-        deployed = saltcloud.utils.deploy_script(
-            host=data.public_ips[0],
-            username='root',
-            password=__opts__['LINODE.password'],
-            script=deploy_script.script,
-            name=vm_['name'],
-            start_action=__opts__['start_action'],
-            sock_dir=__opts__['sock_dir'])
+        deploy_kwargs = {
+            'host': data.public_ips[0],
+            'username': 'root',
+            'password': __opts__['LINODE.password'],
+            'script': deploy_script.script,
+            'name': vm_['name'],
+            'deploy_command': '/tmp/deploy.sh',
+            'start_action': __opts__['start_action'],
+            'sock_dir': __opts__['sock_dir'],
+            'conf_file': __opts__['conf_file'],
+            'minion_pem': vm_['priv_key'],
+            'minion_pub': vm_['pub_key'],
+            }
+        deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
+        deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
         else:

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -170,14 +170,20 @@ def create(vm_):
         raise
 
     if __opts__['deploy'] is True:
-        deployed = saltcloud.utils.deploy_script(
-            host=ip_address,
-            username='root',
-            password=data.extra['password'],
-            script=deploy_script.script,
-            name=vm_['name'],
-            start_action=__opts__['start_action'],
-            sock_dir=__opts__['sock_dir'])
+        deploy_kwargs = {
+            'host': ip_address,
+            'username': 'root',
+            'password': data.extra['password'],
+            'script': deploy_script.script,
+            'name': vm_['name'],
+            'start_action': __opts__['start_action'],
+            'sock_dir': __opts__['sock_dir'],
+            'conf_file': __opts__['conf_file'],
+            'minion_pem': vm_['priv_key'],
+            'minion_pub': vm_['pub_key'],
+            }
+        deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
+        deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
         else:

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -24,6 +24,7 @@ def cloud_config(path):
             'ssh_auth': '',
             'keysize': 4096,
             'os': '',
+            'script': 'bootstrap-salt-minion',
             'start_action': None,
             # Logging defaults
             'log_file': '/var/log/salt/cloud',


### PR DESCRIPTION
Also re-factors the remaining clouds to use deploy_kwargs, which lets the user take advantage of this. Resolves #149.
