### PR TITLE
Add generic wrappers for salt-bootstrap

### DIFF
--- a/saltcloud/deploy/curl-bootstrap-git.sh
+++ b/saltcloud/deploy/curl-bootstrap-git.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# This is a generic wrapper for the salt-bootstrap script at:
+#
+# https://github.com/saltstack/salt-bootstrap
+# 
+# It has been designed as an example, to be customized for your own needs.
+
+curl -L http://bootstrap.saltstack.org | sudo sh -s git develop

--- a/saltcloud/deploy/curl-bootstrap.sh
+++ b/saltcloud/deploy/curl-bootstrap.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# This is a generic wrapper for the salt-bootstrap script at:
+#
+# https://github.com/saltstack/salt-bootstrap
+# 
+# It has been designed as an example, to be customized for your own needs.
+
+curl -L http://bootstrap.saltstack.org | sudo sh

--- a/saltcloud/deploy/python-bootstrap.sh
+++ b/saltcloud/deploy/python-bootstrap.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# This is a generic wrapper for the salt-bootstrap script at:
+#
+# https://github.com/saltstack/salt-bootstrap
+# 
+# It has been designed as an example, to be customized for your own needs.
+
+python -m urllib "http://bootstrap.saltstack.org" | sudo sh

--- a/saltcloud/deploy/wget-bootstrap-nocert.sh
+++ b/saltcloud/deploy/wget-bootstrap-nocert.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# This is a generic wrapper for the salt-bootstrap script at:
+#
+# https://github.com/saltstack/salt-bootstrap
+# 
+# It has been designed as an example, to be customized for your own needs.
+
+wget --no-check-certificate -O - http://bootstrap.saltstack.org | sudo sh

--- a/saltcloud/deploy/wget-bootstrap.sh
+++ b/saltcloud/deploy/wget-bootstrap.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# This is a generic wrapper for the salt-bootstrap script at:
+#
+# https://github.com/saltstack/salt-bootstrap
+# 
+# It has been designed as an example, to be customized for your own needs.
+
+wget -O - http://bootstrap.saltstack.org | sudo sh


### PR DESCRIPTION
This gives another method for the user to add their own commands before or after the deployment, without using startup states.
