### PR TITLE
Support for multiple regions in AWS

### DIFF
--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -439,15 +439,18 @@ def check_name(name, pattern):
                             name, pattern))
 
 
-def namespaced_function(function, global_dict):
+def namespaced_function(function, global_dict, defaults=None):
     """
     Redefine(clone) a function under a different globals() namespace scope
     """
+    if defaults is None:
+        defaults = function.__defaults__
+
     namespaced_function = types.FunctionType(
         function.__code__,
         global_dict,
         name=function.__name__,
-        argdefs=function.__defaults__
+        argdefs=defaults
     )
     namespaced_function.__dict__.update(function.__dict__)
     return namespaced_function

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -152,6 +152,11 @@ class ExecutionOptionsMixIn(object):
             # Include description here as a string
         )
         group.add_option(
+            '-L', '--location',
+            default='',
+            help='Specify which region to connect'
+        )
+        group.add_option(
             '-a', '--action',
             default='',
             help=('Perform an action that may be specific to this cloud'


### PR DESCRIPTION
Changes:
- added cli location parameter (-L or --location)
- initialize libcloud functions with a region-specific connection object
- modified namespaced_function to set default parameter when wrapping methods from libcloudfuncs

This patch should allow the region to be specified in the following order (each overriding the former):
1. Global salt-cloud config
2. Cloud profile setting
3. CLI parameter

Only AWS is supported in this patch.
