### PR TITLE
Lay down master config files on the minion

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -196,6 +196,13 @@ class Cloud(object):
         vm_['priv_key'] = priv
         ok = False
 
+        if vm_['make_master'] is True:
+            master_priv, master_pub = saltcloud.utils.gen_keys(
+                saltcloud.utils.get_option('keysize', self.opts, vm_)
+                )
+            vm_['master_pub'] = master_pub
+            vm_['master_pem'] = master_priv
+
         if 'script' in self.opts:
             vm_['os'] = self.opts['script']
         if 'script' in vm_:

--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -274,8 +274,18 @@ def create(vm_):
             'minion_pub': vm_['pub_key'],
             }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
+
+        # Deploy salt-master files, if necessary
+        if vm_['make_master'] is True:
+            deploy_kwargs['master_pub'] = vm_['master_pub']
+            deploy_kwargs['master_pem'] = vm_['master_pem']
+            master_conf = saltcloud.utils.master_conf_string(__opts__, vm_)
+            if master_conf:
+                deploy_kwargs['master_conf'] = master_conf
+
         if username == 'root':
             deploy_kwargs['deploy_command'] = '/tmp/deploy.sh'
+
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -172,6 +172,22 @@ def minion_conf_string(opts, vm_):
     return yaml.safe_dump(minion, default_flow_style=False)
 
 
+def master_conf_string(opts, vm_):
+    '''
+    Return a string to be passed into the deployment script for the master
+    configuration file
+    '''
+    master = {}
+
+    master.update(opts.get('master', {}))
+    master.update(vm_.get('master', {}))
+
+    master.update(opts.get('map_master', {}))
+    master.update(vm_.get('map_master', {}))
+
+    return yaml.safe_dump(master, default_flow_style=False)
+
+
 def wait_for_ssh(host, port=22, timeout=900):
     '''
     Wait until an ssh connection can be made on a specified host

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -257,9 +257,9 @@ def deploy_script(host, port=22, timeout=900, username='root',
                   password=None, key_filename=None, script=None,
                   deploy_command='/tmp/deploy.sh', sudo=False, tty=None,
                   name=None, pub_key=None, sock_dir=None, provider=None,
-                  conf_file=None, start_action=None, minion_pub=None,
-                  minion_pem=None, minion_conf=None, master_pub=None,
-                  master_pem=None, master_conf=None):
+                  conf_file=None, start_action=None, make_master=False,
+                  master_pub=None, master_pem=None, master_conf=None,
+                  minion_pub=None, minion_pem=None, minion_conf=None):
     '''
     Copy a deploy script to a remote server, execute it, and remove it
     '''
@@ -339,6 +339,8 @@ def deploy_script(host, port=22, timeout=900, username='root',
             # Run the deploy script
             if script:
                 log.debug('Executing /tmp/deploy.sh')
+                if make_master:
+                    deploy_command += ' -m'
                 if 'bootstrap-salt-minion' in script:
                     deploy_command += ' -c /tmp/'
                 root_cmd(deploy_command, tty, sudo, **kwargs)


### PR DESCRIPTION
Addresses issue #204, by giving salt-cloud (and aws as our guinea pig) the ability to lay down master config files.

In order to enable this, a user would set the following option in the profile/map:

```
make_master: True
```

If this is set, then master.pub and master.pem will be generated. In order to also generate master config, a master section (similar to the minion section) must be set. For instance:

```
master:
    user: root
    interface: 0.0.0.0
```

If no master section is specified, then no master config will be laid down. Since the master config rarely needs to be modified, this is appropriate for distributions whose install package already lays down a master config file (this is not always the case).

This does not completely resolve issue #204, since salt-bootstrap must also be able to handle the master configs.
