### PR TITLE
Don't require make_master config option in cloud.profile

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -196,7 +196,7 @@ class Cloud(object):
         vm_['priv_key'] = priv
         ok = False
 
-        if vm_['make_master'] is True:
+        if 'make_master' in vm_ and vm_['make_master'] is True:
             master_priv, master_pub = saltcloud.utils.gen_keys(
                 saltcloud.utils.get_option('keysize', self.opts, vm_)
                 )

--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -276,7 +276,7 @@ def create(vm_):
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
 
         # Deploy salt-master files, if necessary
-        if vm_['make_master'] is True:
+        if 'make_master' in vm_ and vm_['make_master'] is True:
             deploy_kwargs['master_pub'] = vm_['master_pub']
             deploy_kwargs['master_pem'] = vm_['master_pem']
             master_conf = saltcloud.utils.master_conf_string(__opts__, vm_)


### PR DESCRIPTION
Diff should be self-explanatory - an exception is thrown without this config option present when creating a new node.
