### PR TITLE
Include cli options into loaded config dictionary.

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -11,8 +11,8 @@ Primary interfaces for the salt-cloud system
 # the VM data will be in opts['vm']
 
 # Import python libs
-import optparse
 import os
+import logging
 
 # Import salt libs
 import saltcloud.config
@@ -23,6 +23,9 @@ import salt.output
 # Import saltcloud libs
 from saltcloud.utils import parsers
 from saltcloud.libcloudfuncs import libcloud_version
+
+
+log = logging.getLogger(__name__)
 
 
 class SaltCloud(parsers.SaltCloudParser):
@@ -39,8 +42,7 @@ class SaltCloud(parsers.SaltCloudParser):
         self.setup_logfile_logger()
 
         # Late imports so logging works as expected
-        import logging
-        logging.getLogger(__name__).info('salt-cloud starting')
+        log.info('salt-cloud starting')
         import saltcloud.cloud
         mapper = saltcloud.cloud.Map(self.config)
 
@@ -57,7 +59,7 @@ class SaltCloud(parsers.SaltCloudParser):
                   '\n\tDestination: {1}'.format(url, deploy_path))
             f = open(deploy_path, 'w')
             f.write(req.read())
-            f.close()            
+            f.close()
 
         if self.selected_query_option is not None:
             if self.options.map:
@@ -122,7 +124,7 @@ class SaltCloud(parsers.SaltCloudParser):
             self.exit(0)
 
         if self.options.action and (self.config.get('names', None) or
-                                     self.options.map):
+                                    self.options.map):
             if self.options.map:
                 names = mapper.delete_map(query='list_nodes')
             else:
@@ -175,7 +177,6 @@ class SaltCloud(parsers.SaltCloudParser):
             except Exception as exc:
                 print('There was a query error: {0}'.format(exc))
             self.exit(0)
-
 
     def print_confirm(self, msg):
         if self.options.assume_yes:

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -26,6 +26,7 @@ try:
 except:
     log.debug('Mako not available')
 
+
 class Cloud(object):
     '''
     An object for the creation of new VMs
@@ -244,7 +245,11 @@ class Cloud(object):
                     found = True
                     if name in current_boxen:
                         # The specified VM already exists, don't make it anew
-                        log.warn("{0} already exists on {1}".format(name, current_boxen[name]))
+                        log.warn(
+                            '{0} already exists on {1}'.format(
+                                name, current_boxen[name]
+                            )
+                        )
                         continue
                     vm_['name'] = name
                     if self.opts['parallel']:
@@ -254,7 +259,9 @@ class Cloud(object):
                     else:
                         self.create(vm_)
         if not found:
-            log.error('Profile {0} is not defined'.format(self.opts['profile']))
+            log.error(
+                'Profile {0} is not defined'.format(self.opts['profile'])
+            )
 
     def do_action(self, names, kwargs):
         '''
@@ -309,7 +316,7 @@ class Map(Cloud):
             for vm in vms:
                 if provider not in full_map:
                     full_map[provider] = {}
-    
+
                 if vm in query_map[provider]:
                     full_map[provider][vm] = query_map[provider][vm]
                 else:
@@ -336,9 +343,9 @@ class Map(Cloud):
             with open(self.opts['map'], 'rb') as fp_:
                 try:
                     #open mako file
-                    temp_ = Template(open(fp_, 'r').read()) 
+                    temp_ = Template(open(fp_, 'r').read())
                     #render as yaml
-                    map_ = temp_.render() 
+                    map_ = temp_.render()
                 except:
                     map_ = yaml.load(fp_.read())
         except Exception as exc:

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -37,15 +37,15 @@ class CloudConfigMixIn(object):
         group.add_option(
             '-M', '--master-config',
             default='/etc/salt/master',
-            help=('The location of the salt master config file. Default: '
-                  '%default')
+            help='The location of the salt master config file. '
+                 'Default: %default'
         )
         group.add_option(
             '-V', '--profiles', '--vm_config',
             dest='vm_config',
             default='/etc/salt/cloud.profiles',
-            help=('The location of the saltcloud VM config file. Default: '
-                  '%default')
+            help='The location of the saltcloud VM config file. '
+                 'Default: %default'
         )
         self.add_option_group(group)
 
@@ -135,8 +135,8 @@ class ExecutionOptionsMixIn(object):
             '-H', '--hard',
             default=False,
             action='store_true',
-            help=('Delete all VMs that are not defined in the map file '
-                  'CAUTION!!! This operation can irrevocably destroy VMs!')
+            help='Delete all VMs that are not defined in the map file '
+                 'CAUTION!!! This operation can irrevocably destroy VMs!'
         )
         group.add_option(
             '-d', '--destroy',
@@ -161,7 +161,8 @@ class ExecutionOptionsMixIn(object):
             '-u', '--update-bootstrap',
             default=False,
             action='store_true',
-            help='Update salt-bootstrap to the latest develop version on GitHub'
+            help='Update salt-bootstrap to the latest develop version on '
+                 'GitHub'
         )
         group.add_option(
             '-y', '--assume-yes',
@@ -170,6 +171,14 @@ class ExecutionOptionsMixIn(object):
             help='Default yes in answer to all confirmation questions'
         )
         self.add_option_group(group)
+
+    def process_profile(self):
+        # This key/value pair needs to be in the loaded config dictionary
+        self.config['profile'] = self.options.profile
+
+    def process_parallel(self):
+        # This key/value pair needs to be in the loaded config dictionary
+        self.config['parallel'] = self.options.parallel
 
     def _mixin_after_parsed(self):
         if not self.options.map:

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -77,12 +77,19 @@ class CloudConfigMixIn(object):
         # Done in CloudConfigMixIn.process_vm_config()
 
         # 4th - Override config with cli options
-        # Done in parsers.MergeConfigMixIn,.__merge_config_with_cli()
+        # Done in parsers.MergeConfigMixIn.__merge_config_with_cli()
 
         # Remove log_level_logfile from config if set to None so it can be
         # equal to console log_level
         if self.config['log_level_logfile'] is None:
             self.config.pop('log_level_logfile')
+
+    def setup_config(self):
+        '''
+        This method needs to be defined in order for `parsers.MergeConfigMixIn`
+        to do it's job.
+        '''
+        return {}
 
     def process_master_config(self):
         self.config = salt.config.master_config(
@@ -171,18 +178,6 @@ class ExecutionOptionsMixIn(object):
             help='Default yes in answer to all confirmation questions'
         )
         self.add_option_group(group)
-
-    def process_profile(self):
-        # This key/value pair needs to be in the loaded config dictionary
-        self.config['profile'] = self.options.profile
-
-    def process_parallel(self):
-        # This key/value pair needs to be in the loaded config dictionary
-        self.config['parallel'] = self.options.parallel
-
-    def _mixin_after_parsed(self):
-        if not self.options.map:
-            self.config['map'] = None
 
 
 class CloudQueriesMixIn(object):


### PR DESCRIPTION
The merge with cli mix in, only merges option keys which exist in both places, cli options and loaded config. Since neither `profile` not `parallel` existed in any of the default config dictionary, not the loaded config files, that info was not getting included.
