### PR TITLE
proposed fix for missing data object issue.

### DIFF
--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -252,18 +252,18 @@ def create(vm_):
     ex_securitygroup = securitygroup(vm_)
     if ex_securitygroup:
         kwargs['ex_securitygroup'] = ex_securitygroup
-
-    try:
-        data = conn.create_node(**kwargs)
-    except Exception as exc:
-        err = ('Error creating {0} on AWS\n\n'
-               'The following exception was thrown by libcloud when trying to '
-               'run the initial deployment: \n{1}').format(
-                       vm_['name'], exc
-                       )
-        sys.stderr.write(err)
-        log.error(err)
-        return False
+    while not data:
+      try:
+          data = conn.create_node(**kwargs)
+      except Exception as exc:
+          err = ('Error creating {0} on AWS\n\n'
+                 'The following exception was thrown by libcloud when trying to '
+                 'run the initial deployment: \n{1}').format(
+                         vm_['name'], exc
+                         )
+          sys.stderr.write(err)
+          log.error(err)
+          return False
     log.info('Created node {0}'.format(vm_['name']))
     waiting_for_ip = 0
     while not data.public_ips:


### PR DESCRIPTION
should fix this sporadic failure (happens between ~20-30% of the time when starting minions) when creating minions on aws:

``` python 
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python2.7/dist-packages/saltcloud/cloud.py", line 399, in <lambda>
    target=lambda: self.create(tvm)
  File "/usr/local/lib/python2.7/dist-packages/saltcloud/cloud.py", line 206, in create
    ok = self.clouds['{0}.create'.format(self.provider(vm_))](vm_)
  File "/usr/local/lib/python2.7/dist-packages/saltcloud/clouds/aws.py", line 240, in create
    while not data.public_ips:
AttributeError: 'NoneType' object has no attribute 'public_ips'
```
