### PR TITLE
Allow user to keep tmp files without code diving

### DIFF
--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -294,6 +294,7 @@ def create(vm_):
             'sock_dir': __opts__['sock_dir'],
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
+            'keep_tmp': __opts__['keep_tmp'],
         }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(
             __opts__, vm_

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -111,6 +111,7 @@ def create(vm_):
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
+            'keep_tmp': __opts__['keep_tmp'],
             }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)

--- a/saltcloud/clouds/ibmsce.py
+++ b/saltcloud/clouds/ibmsce.py
@@ -150,6 +150,7 @@ def create(vm_):
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
+            'keep_tmp': __opts__['keep_tmp'],
         }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(
             __opts__, vm_

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -102,6 +102,7 @@ def create(vm_):
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
+            'keep_tmp': __opts__['keep_tmp'],
             }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -132,6 +132,7 @@ def create(vm_):
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
+            'keep_tmp': __opts__['keep_tmp'],
             }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -243,6 +243,7 @@ def create(vm_):
         'start_action': __opts__['start_action'],
         'minion_pem': vm_['priv_key'],
         'minion_pub': vm_['pub_key'],
+        'keep_tmp': __opts__['keep_tmp'],
     }
 
     deployargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -176,6 +176,7 @@ def create(vm_):
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
+            'keep_tmp': __opts__['keep_tmp'],
             }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -264,7 +264,8 @@ def deploy_script(host, port=22, timeout=900, username='root',
                   name=None, pub_key=None, sock_dir=None, provider=None,
                   conf_file=None, start_action=None, make_master=False,
                   master_pub=None, master_pem=None, master_conf=None,
-                  minion_pub=None, minion_pem=None, minion_conf=None):
+                  minion_pub=None, minion_pem=None, minion_conf=None,
+                  keep_tmp=False):
     '''
     Copy a deploy script to a remote server, execute it, and remove it
     '''
@@ -364,31 +365,38 @@ def deploy_script(host, port=22, timeout=900, username='root',
                     deploy_command += ' -c /tmp/'
                 root_cmd(deploy_command, tty, sudo, **kwargs)
                 log.debug('Executed /tmp/deploy.sh')
+
                 # Remove the deploy script
-                ssh.exec_command('rm /tmp/deploy.sh')
-                log.debug('Removed /tmp/deploy.sh')
+                if not keep_tmp:
+                    ssh.exec_command('rm /tmp/deploy.sh')
+                    log.debug('Removed /tmp/deploy.sh')
+
+            if keep_tmp:
+                log.debug('Not removing deloyment files from /tmp/')
 
             # Remove minion configuration
-            if minion_pub:
-                ssh.exec_command('rm /tmp/minion.pub')
-                log.debug('Removed /tmp/minion.pub')
-            if minion_pem:
-                ssh.exec_command('rm /tmp/minion.pem')
-                log.debug('Removed /tmp/minion.pem')
-            if minion_conf:
-                ssh.exec_command('rm /tmp/minion')
-                log.debug('Removed /tmp/minion')
+            if not keep_tmp:
+                if minion_pub:
+                    ssh.exec_command('rm /tmp/minion.pub')
+                    log.debug('Removed /tmp/minion.pub')
+                if minion_pem:
+                    ssh.exec_command('rm /tmp/minion.pem')
+                    log.debug('Removed /tmp/minion.pem')
+                if minion_conf:
+                    ssh.exec_command('rm /tmp/minion')
+                    log.debug('Removed /tmp/minion')
 
             # Remove master configuration
-            if master_pub:
-                ssh.exec_command('rm /tmp/master.pub')
-                log.debug('Removed /tmp/master.pub')
-            if master_pem:
-                ssh.exec_command('rm /tmp/master.pem')
-                log.debug('Removed /tmp/master.pem')
-            if master_conf:
-                ssh.exec_command('rm /tmp/master')
-                log.debug('Removed /tmp/master')
+            if not keep_tmp:
+                if master_pub:
+                    ssh.exec_command('rm /tmp/master.pub')
+                    log.debug('Removed /tmp/master.pub')
+                if master_pem:
+                    ssh.exec_command('rm /tmp/master.pem')
+                    log.debug('Removed /tmp/master.pem')
+                if master_conf:
+                    ssh.exec_command('rm /tmp/master')
+                    log.debug('Removed /tmp/master')
 
             if start_action:
                 queuereturn = queue.get()

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -177,6 +177,12 @@ class ExecutionOptionsMixIn(object):
             action='store_true',
             help='Default yes in answer to all confirmation questions'
         )
+        group.add_option(
+            '--keep-tmp',
+            default=False,
+            action='store_true',
+            help='Do not remove files from /tmp/ after deploy.sh finishes'
+        )
         self.add_option_group(group)
 
 


### PR DESCRIPTION
This will save time when troubleshooting salt-bootstrap. @s0undt3ch may especially appreciate this.
