### PR TITLE
Allow script_args to be passed to deploy.sh

### DIFF
--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -295,6 +295,7 @@ def create(vm_):
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
             'keep_tmp': __opts__['keep_tmp'],
+            'script_args': vm_['script_args'],
         }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(
             __opts__, vm_

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -112,6 +112,7 @@ def create(vm_):
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
             'keep_tmp': __opts__['keep_tmp'],
+            'script_args': vm_['script_args'],
             }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)

--- a/saltcloud/clouds/ibmsce.py
+++ b/saltcloud/clouds/ibmsce.py
@@ -151,6 +151,7 @@ def create(vm_):
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
             'keep_tmp': __opts__['keep_tmp'],
+            'script_args': vm_['script_args'],
         }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(
             __opts__, vm_

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -103,6 +103,7 @@ def create(vm_):
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
             'keep_tmp': __opts__['keep_tmp'],
+            'script_args': vm_['script_args'],
             }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -133,6 +133,7 @@ def create(vm_):
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
             'keep_tmp': __opts__['keep_tmp'],
+            'script_args': vm_['script_args'],
             }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -244,6 +244,7 @@ def create(vm_):
         'minion_pem': vm_['priv_key'],
         'minion_pub': vm_['pub_key'],
         'keep_tmp': __opts__['keep_tmp'],
+        'script_args': vm_['script_args'],
     }
 
     deployargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -177,6 +177,7 @@ def create(vm_):
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
             'keep_tmp': __opts__['keep_tmp'],
+            'script_args': vm_['script_args'],
             }
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -17,6 +17,7 @@ CLOUD_CONFIG_DEFAULTS = {
     'os': '',
     'script': 'bootstrap-salt-minion',
     'start_action': None,
+    'script_args': None,
     # Logging defaults
     'log_file': '/var/log/salt/cloud',
     'log_level': None,

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -265,7 +265,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
                   conf_file=None, start_action=None, make_master=False,
                   master_pub=None, master_pem=None, master_conf=None,
                   minion_pub=None, minion_pem=None, minion_conf=None,
-                  keep_tmp=False):
+                  keep_tmp=False, script_args=None):
     '''
     Copy a deploy script to a remote server, execute it, and remove it
     '''
@@ -363,8 +363,10 @@ def deploy_script(host, port=22, timeout=900, username='root',
                     deploy_command += ' -m'
                 if 'bootstrap-salt-minion' in script:
                     deploy_command += ' -c /tmp/'
+                if script_args:
+                    deploy_command += ' {0}'.format(script_args)
                 root_cmd(deploy_command, tty, sudo, **kwargs)
-                log.debug('Executed /tmp/deploy.sh')
+                log.debug('Executed command {0}'.format(deploy_command))
 
                 # Remove the deploy script
                 if not keep_tmp:


### PR DESCRIPTION
Resolves #218. Sample configuration might look like:

``` yaml
aws-amazon:
    provider: aws
    image: ami-1624987f
    size: Micro Instance
    ssh_username: ec2-user
    script: bootstrap-salt-minion
    script_args: -c /tmp/
```

This will help save some users from having to write wrapper scripts, just to pass options along to salt-bootstrap.

Tagging @s0undt3ch, @akoumjian.
