### PR TITLE
Sudo is being prepended later if needed.

### DIFF
--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -251,7 +251,7 @@ def create(vm_):
 
     deployargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
     if 'ssh_username' in vm_:
-        deployargs['deploy_command'] = 'sudo /tmp/deploy.sh'
+        deployargs['deploy_command'] = '/tmp/deploy.sh'
         deployargs['username'] = vm_['ssh_username']
         deployargs['tty'] = True
     else:


### PR DESCRIPTION
If sudo is needed, it can be set in the cloud profile.  If it is
set there, then we end up with 'sudo sudo /tmp/deploy.sh', which
just looks ugly.
