### PR TITLE
Replace Paramiko with sshpass

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,9 +22,9 @@ Depends: ${python:Depends},
          python,
          python-libcloud,
          python-boto,
-         python-paramiko,
          python-yaml,
-         salt-common
+         salt-common,
+         sshpass
 Description: public cloud VM management system
  provision virtual machines on various public clouds via a cleanly 
  controlled profile and mapping system.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,7 +46,6 @@ class Mock(object):
             return Mock()
 
 MOCK_MODULES = [
-    'paramiko',
     'salt',
     'salt.utils',
     'salt.utils.event',

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ PyYAML
 apache-libcloud
 paramiko
 botocore
+sshpass

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,4 @@
 salt
 PyYAML
 apache-libcloud
-paramiko
 botocore
-sshpass

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -305,16 +305,12 @@ def deploy_script(host, port=22, timeout=900, username='root',
                     'There was an error in deploy_script: {0}'.format(exc)
                 )
             if provider == 'ibmsce':
-                ssh.exec_command(
-                    'sudo sed -i "s/#Subsystem/Subsystem/" '
+                subsys_command = (
+                    'sed -i "s/#Subsystem/Subsystem/" '
                     '/etc/ssh/sshd_config'
                 )
-                stdin, stdout, stderr = ssh.exec_command(
-                    'sudo service sshd restart'
-                )
-                for line in stdout:
-                    sys.stdout.write(line)
-                ssh.connect(**kwargs)
+                root_cmd(subsys_command, tty, sudo, **kwargs)
+                root_cmd('service sshd restart', tty, sudo, **kwargs)
 
             # Minion configuration
             if minion_pem:

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -321,25 +321,25 @@ def deploy_script(host, port=22, timeout=900, username='root',
 
             # Minion configuration
             if minion_pem:
-                sftp_file(sftp, host, '/tmp/minion.pem', minion_pem, kwargs)
+                scp_file('/tmp/minion.pem', minion_pem, kwargs)
                 ssh.exec_command('chmod 600 /tmp/minion.pem')
             if minion_pub:
-                sftp_file(sftp, host, '/tmp/minion.pub', minion_pub, kwargs)
+                scp_file('/tmp/minion.pub', minion_pub, kwargs)
             if minion_conf:
-                sftp_file(sftp, host, '/tmp/minion', minion_conf, kwargs)
+                scp_file('/tmp/minion', minion_conf, kwargs)
 
             # Master configuration
             if master_pem:
-                sftp_file(sftp, host, '/tmp/master.pem', master_pem, kwargs)
+                scp_file('/tmp/master.pem', master_pem, kwargs)
                 ssh.exec_command('chmod 600 /tmp/master.pem')
             if master_pub:
-                sftp_file(sftp, host, '/tmp/master.pub', master_pub, kwargs)
+                scp_file('/tmp/master.pub', master_pub, kwargs)
             if master_conf:
-                sftp_file(sftp, host, '/tmp/master', master_conf, kwargs)
+                scp_file('/tmp/master', master_conf, kwargs)
 
             # The actual deploy script
             if script:
-                sftp_file(sftp, host, '/tmp/deploy.sh', script, kwargs)
+                scp_file('/tmp/deploy.sh', script, kwargs)
             ssh.exec_command('chmod +x /tmp/deploy.sh')
 
             newtimeout = timeout - (time.mktime(time.localtime()) - starttime)
@@ -438,16 +438,15 @@ def deploy_script(host, port=22, timeout=900, username='root',
     return False
 
 
-def sftp_file(transport, host, dest_path, contents, kwargs):
+def scp_file(dest_path, contents, kwargs):
     '''
-    Given an established sftp session, this function will copy a file to a
-    server using said sftp transport
+    Use scp to copy a file to a server    
     '''
     tmpfh, tmppath = tempfile.mkstemp()
     tmpfile = open(tmppath, 'w')
     tmpfile.write(contents)
     tmpfile.close()
-    log.debug('Uploading {0} to {1}'.format(dest_path, host))
+    log.debug('Uploading {0} to {1}'.format(dest_path, kwargs['hostname']))
     cmd = 'scp -oStrictHostKeyChecking=no {0} {1}@{2}:{3}'.format(
         tmppath,
         kwargs['username'],

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -285,8 +285,6 @@ def deploy_script(host, port=22, timeout=900, username='root',
                 )
             )
             newtimeout = timeout - (time.mktime(time.localtime()) - starttime)
-            ssh = paramiko.SSHClient()
-            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             kwargs = {'hostname': host,
                       'port': 22,
                       'username': username,
@@ -298,7 +296,6 @@ def deploy_script(host, port=22, timeout=900, username='root',
                 log.debug('Using {0} as the key_filename'.format(key_filename))
                 kwargs['key_filename'] = key_filename
             try:
-                ssh.connect(**kwargs)
                 log.debug('SSH connection to {0} successful'.format(host))
             except Exception as exc:
                 log.error(

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -315,9 +315,6 @@ def deploy_script(host, port=22, timeout=900, username='root',
                 for line in stdout:
                     sys.stdout.write(line)
                 ssh.connect(**kwargs)
-            sftp = ssh.get_transport()
-            sftp.open_session()
-            sftp = paramiko.SFTPClient.from_transport(sftp)
 
             # Minion configuration
             if minion_pem:

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -319,7 +319,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
             # Minion configuration
             if minion_pem:
                 scp_file('/tmp/minion.pem', minion_pem, kwargs)
-                ssh.exec_command('chmod 600 /tmp/minion.pem')
+                root_cmd('chmod 600 /tmp/minion.pem', tty, sudo, **kwargs)
             if minion_pub:
                 scp_file('/tmp/minion.pub', minion_pub, kwargs)
             if minion_conf:
@@ -328,7 +328,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
             # Master configuration
             if master_pem:
                 scp_file('/tmp/master.pem', master_pem, kwargs)
-                ssh.exec_command('chmod 600 /tmp/master.pem')
+                root_cmd('chmod 600 /tmp/master.pem', tty, sudo, **kwargs)
             if master_pub:
                 scp_file('/tmp/master.pub', master_pub, kwargs)
             if master_conf:
@@ -337,7 +337,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
             # The actual deploy script
             if script:
                 scp_file('/tmp/deploy.sh', script, kwargs)
-            ssh.exec_command('chmod +x /tmp/deploy.sh')
+            root_cmd('chmod +x /tmp/deploy.sh', tty, sudo, **kwargs)
 
             newtimeout = timeout - (time.mktime(time.localtime()) - starttime)
             queue = None
@@ -369,7 +369,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
 
                 # Remove the deploy script
                 if not keep_tmp:
-                    ssh.exec_command('rm /tmp/deploy.sh')
+                    root_cmd('rm /tmp/deploy.sh', tty, sudo, **kwargs)
                     log.debug('Removed /tmp/deploy.sh')
 
             if keep_tmp:
@@ -378,25 +378,25 @@ def deploy_script(host, port=22, timeout=900, username='root',
             # Remove minion configuration
             if not keep_tmp:
                 if minion_pub:
-                    ssh.exec_command('rm /tmp/minion.pub')
+                    root_cmd('rm /tmp/minion.pub', tty, sudo, **kwargs)
                     log.debug('Removed /tmp/minion.pub')
                 if minion_pem:
-                    ssh.exec_command('rm /tmp/minion.pem')
+                    root_cmd('rm /tmp/minion.pem', tty, sudo, **kwargs)
                     log.debug('Removed /tmp/minion.pem')
                 if minion_conf:
-                    ssh.exec_command('rm /tmp/minion')
+                    root_cmd('rm /tmp/minion', tty, sudo, **kwargs)
                     log.debug('Removed /tmp/minion')
 
             # Remove master configuration
             if not keep_tmp:
                 if master_pub:
-                    ssh.exec_command('rm /tmp/master.pub')
+                    root_cmd('rm /tmp/master.pub', tty, sudo, **kwargs)
                     log.debug('Removed /tmp/master.pub')
                 if master_pem:
-                    ssh.exec_command('rm /tmp/master.pem')
+                    root_cmd('rm /tmp/master.pem', tty, sudo, **kwargs)
                     log.debug('Removed /tmp/master.pem')
                 if master_conf:
-                    ssh.exec_command('rm /tmp/master')
+                    root_cmd('rm /tmp/master', tty, sudo, **kwargs)
                     log.debug('Removed /tmp/master')
 
             if start_action:

--- a/saltcloud/version.py
+++ b/saltcloud/version.py
@@ -8,7 +8,6 @@ def versions_report():
     libs = (
         ("Salt", "salt", "__version__"),
         ("Apache Libcloud", "libcloud", "__version__"),
-        ("Paramiko", "paramiko", "__version__"),
         ("PyYAML", "yaml", "__version__"),
     )
 


### PR DESCRIPTION
Using Paramiko has caused us nothing but pain, and we were only using it because we didn't have a way to pass a password to the ssh command. The sshpass package is tiny and widely available. The tradeoff here in terms of performance is that we're giving up the overhead of a massive SSH library that we only used a fraction of, for the overhead of shelling out more. I'm okay with that.

@herlo, @seanchannel and @cedwards will want to be aware that we have removed paramiko as a dependency, and added sshpass. I've been able to find it in epel, packages.debian.org, packages.ubuntu,org and even in the Arch community repo.
