### PR TITLE
Handle the rename of the bootstrap script

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -49,17 +49,13 @@ class SaltCloud(parsers.SaltCloudParser):
 
         if self.options.update_bootstrap:
             import urllib
-            branch = 'develop'
-            url = (
-                'https://raw.github.com/saltstack/salt-bootstrap/{0}/'
-                'bootstrap-salt-minion.sh'.format(branch)
-            )
+            url = 'http://bootstrap.saltstack.org'
             req = urllib.urlopen(url)
             deploy_path = os.path.join(
                 os.path.dirname(os.path.dirname(__file__)),
-                'saltcloud', 'deploy', 'bootstrap-salt-minion.sh'
+                'saltcloud', 'deploy', 'bootstrap-salt.sh'
             )
-            print('Updating bootstrap-salt-minion.sh.'
+            print('Updating bootstrap-salt.sh.'
                   '\n\tSource:      {0}'
                   '\n\tDestination: {1}'.format(url, deploy_path))
             with salt.utils.fopen(deploy_path, 'w') as fp_:

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -15,7 +15,7 @@ CLOUD_CONFIG_DEFAULTS = {
     'ssh_auth': '',
     'keysize': 4096,
     'os': '',
-    'script': 'bootstrap-salt-minion',
+    'script': 'bootstrap-salt',
     'start_action': None,
     'enable_hard_maps': False,
     # Logging defaults

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -338,7 +338,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
                 log.debug('Executing /tmp/deploy.sh')
                 if make_master:
                     deploy_command += ' -m'
-                if 'bootstrap-salt-minion' in script:
+                if 'bootstrap-salt' in script:
                     deploy_command += ' -c /tmp/'
                 if script_args:
                     deploy_command += ' {0}'.format(script_args)


### PR DESCRIPTION
The recent rename in salt-bootstrap caused me a few issues, and then it seemed pertinent to update salt-cloud to match.

I haven't done anything to handle salt-cloud config containing "script: bootstrap-salt-minion", as yet. Really that should be removed from people's config since it's now the default..
