### PR TITLE
Allow salt-cloud to remove ssh keys upon destroy()

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -11,6 +11,7 @@ Salt Cloud Table of Contents
     topics/cloud
     topics/deploy
     topics/config
+    topics/misc
 
     ref/cli/man/salt-cloud
 

--- a/doc/topics/misc.rst
+++ b/doc/topics/misc.rst
@@ -1,0 +1,24 @@
+================================
+Miscellaneous Salt Cloud Options
+================================
+
+This page describes various miscellaneous options available in Salt Cloud
+
+Delete SSH Keys
+===============
+
+When Salt Cloud deploys an instance, the SSH pub key for the instance is added
+to the known_hosts file for the user that ran the salt-cloud command. When an
+instance is deployed, a cloud provider generally recycles the IP address for
+the instance.  When Salt Cloud attempts to deploy an instance using a recycled
+IP address that has previously been accessed from the same machine, the old key
+in the known_hosts file will cause a conflict.
+
+In order to mitigate this issue, Salt Cloud can be configured to remove old
+keys from the known_hosts file when destroying the node. In order to do this,
+the following line needs to be added to the main cloud configuration file:
+
+.. code-block:: yaml
+
+    delete_sshkeys: True
+

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -18,6 +18,7 @@ CLOUD_CONFIG_DEFAULTS = {
     'script': 'bootstrap-salt',
     'start_action': None,
     'enable_hard_maps': False,
+    'delete_sshkeys': False,
     # Logging defaults
     'log_file': '/var/log/salt/cloud',
     'log_level': None,

--- a/saltcloud/libcloudfuncs.py
+++ b/saltcloud/libcloudfuncs.py
@@ -223,6 +223,8 @@ def destroy(name, conn=None):
             __opts__['sock_dir']
         )
         event.fire_event('{0} has been destroyed'.format(name), 'salt-cloud')
+        if __opts__['delete_sshkeys'] is True:
+            saltcloud.utils.remove_sshkey(node.public_ips[0])
         return True
     else:
         log.error('Failed to Destroy VM: {0}'.format(name))

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -542,3 +542,14 @@ def namespaced_function(function, global_dict, defaults=None):
     )
     new_namespaced_function.__dict__.update(function.__dict__)
     return new_namespaced_function
+
+
+def remove_sshkey(host,
+                  known_hosts='{0}/known_hosts'.format(os.environ['HOME'])):
+    '''
+    Remove a host from the known_hosts file
+    '''
+    log.debug('Removing ssh key for {0} from known '
+              'hosts file {1}'.format(host, known_hosts))
+    cmd = 'ssh-keygen -R {0}'.format(host)
+    subprocess.call(cmd, shell=True)


### PR DESCRIPTION
In order to use this, add this to your main salt-cloud config file:

``` yaml
delete_sshkeys: True
```
