### PR TITLE
Use AWS lexicon in documetnation to avoid confusion.

### DIFF
--- a/saltcloud/clouds/aws.py
+++ b/saltcloud/clouds/aws.py
@@ -9,9 +9,9 @@ set in the main cloud config:
 
 .. code-block:: yaml
 
-    # The AWS API authentication id
+    # AWS Access Key id
     AWS.id: GKTADJGHEIQSXMKKRBJ08H
-    # The AWS API authentication key
+    # AWS Secret Access Key
     AWS.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
     # The ssh keyname to use
     AWS.keyname: default


### PR DESCRIPTION
I'll admit, when I first started using salt-cloud a month ago. API key id, did not make sense and was not searchable in AWS documentation. This will help avoid confusion going forward.
