### PR TITLE
Add cloud-specific functions (separate from actions)

### DIFF
--- a/doc/topics/function.rst
+++ b/doc/topics/function.rst
@@ -1,0 +1,13 @@
+===============
+Cloud Functions
+===============
+
+Cloud functions work much the same way as cloud actions, except that they don't
+perform an operation on a specific instance, and so do not need a machine name
+to be specified. However, since they perform an operation on a specific cloud
+provider, that provider must be specified.
+
+.. code-block:: bash
+
+    $ salt-cloud -f aws show_image image=ami-fd20ad94
+

--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -190,6 +190,29 @@ class SaltCloud(parsers.SaltCloudParser):
                 )
             self.exit(0)
 
+        if self.options.function:
+            prov = self.config.get('function', None)
+
+            names = self.config.get('names', None)
+            func = ''
+            kwargs = {}
+
+            if not names:
+                self.error('Not enough arguments were given.')
+
+            for name in names:
+                if '=' in name:
+                    comps = name.split('=')
+                    kwargs[comps[0]] = comps[1]
+                else:
+                    func = name
+
+            if not func:
+                self.error('A function name was not specified.')
+
+            mapper.do_function(prov, func, kwargs)
+            self.exit(0)
+
         if self.options.profile and self.config.get('names', False):
             try:
                 mapper.run_profile()

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -292,9 +292,9 @@ class Cloud(object):
                 if name in names_:
                     fun = '{0}.{1}'.format(prov, self.opts['action'])
                     if kwargs:
-                        self.clouds[fun](name, kwargs)
+                        self.clouds[fun]('action', name, kwargs)
                     else:
-                        self.clouds[fun](name)
+                        self.clouds[fun]('action', name)
                     completed.append(name)
 
         for name in names:
@@ -302,6 +302,17 @@ class Cloud(object):
                 print('{0} was not found, not running {1} action'.format(
                     name, self.opts['action'])
                 )
+
+
+    def do_function(self, prov, func, kwargs):
+        '''
+        Perform an action which may be specific to this cloud provider
+        '''
+        fun = '{0}.{1}'.format(prov, func)
+        if kwargs:
+            self.clouds[fun]('function', kwargs)
+        else:
+            self.clouds[fun]('function')
 
 
 class Map(Cloud):

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -292,9 +292,9 @@ class Cloud(object):
                 if name in names_:
                     fun = '{0}.{1}'.format(prov, self.opts['action'])
                     if kwargs:
-                        self.clouds[fun]('action', name, kwargs)
+                        self.clouds[fun](name, kwargs, call='action')
                     else:
-                        self.clouds[fun]('action', name)
+                        self.clouds[fun](name, call='action')
                     completed.append(name)
 
         for name in names:
@@ -310,9 +310,9 @@ class Cloud(object):
         '''
         fun = '{0}.{1}'.format(prov, func)
         if kwargs:
-            self.clouds[fun]('function', kwargs)
+            self.clouds[fun](call='function', kwargs=kwargs)
         else:
-            self.clouds[fun]('function')
+            self.clouds[fun](call='function')
 
 
 class Map(Cloud):

--- a/saltcloud/clouds/botocore_aws.py
+++ b/saltcloud/clouds/botocore_aws.py
@@ -109,7 +109,7 @@ def __virtual__():
     return 'aws'
 
 
-def enable_term_protect(name):
+def enable_term_protect(arg, name):
     '''
     Enable termination protection on a node
 
@@ -117,10 +117,14 @@ def enable_term_protect(name):
 
         salt-cloud -a enable_term_protect mymachine
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     _toggle_term_protect(name, True)
 
 
-def disable_term_protect(name):
+def disable_term_protect(arg, name):
     '''
     Disable termination protection on a node
 
@@ -128,6 +132,10 @@ def disable_term_protect(name):
 
         salt-cloud -a disable_term_protect mymachine
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     _toggle_term_protect(name, False)
 
 

--- a/saltcloud/clouds/botocore_aws.py
+++ b/saltcloud/clouds/botocore_aws.py
@@ -109,7 +109,7 @@ def __virtual__():
     return 'aws'
 
 
-def enable_term_protect(arg, name):
+def enable_term_protect(name, call=None):
     '''
     Enable termination protection on a node
 
@@ -117,14 +117,14 @@ def enable_term_protect(arg, name):
 
         salt-cloud -a enable_term_protect mymachine
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
     _toggle_term_protect(name, True)
 
 
-def disable_term_protect(arg, name):
+def disable_term_protect(name, call=None):
     '''
     Disable termination protection on a node
 
@@ -132,7 +132,7 @@ def disable_term_protect(arg, name):
 
         salt-cloud -a disable_term_protect mymachine
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -492,11 +492,11 @@ def create_attach_volumes(volumes, location, data):
             )
 
 
-def stop(arg, name):
+def stop(name, call=None):
     '''
     Stop a node
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -512,11 +512,11 @@ def stop(arg, name):
     pprint.pprint(result)
 
 
-def start(arg, name):
+def start(name, call=None):
     '''
     Start a node
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -532,7 +532,7 @@ def start(arg, name):
     pprint.pprint(result)
 
 
-def set_tags(arg, name, tags):
+def set_tags(name, tags, call=None):
     '''
     Set tags for a node
 
@@ -540,7 +540,7 @@ def set_tags(arg, name, tags):
 
         salt-cloud -a set_tags mymachine tag1=somestuff tag2='Other stuff'
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -561,11 +561,11 @@ def set_tags(arg, name, tags):
     return get_tags(name)
 
 
-def get_tags(arg, name):
+def get_tags(name, call=None):
     '''
     Retrieve tags for a node
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -584,7 +584,7 @@ def get_tags(arg, name):
     return result
 
 
-def del_tags(arg, name, kwargs):
+def del_tags(name, kwargs, call=None):
     '''
     Delete tags for a node
 
@@ -592,7 +592,7 @@ def del_tags(arg, name, kwargs):
 
         salt-cloud -a del_tags mymachine tag1,tag2,tag3
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -608,7 +608,7 @@ def del_tags(arg, name, kwargs):
     return get_tags(name)
 
 
-def rename(arg, name, kwargs):
+def rename(name, kwargs, call=None):
     '''
     Properly rename a node. Pass in the new name as "new name".
 
@@ -616,7 +616,7 @@ def rename(arg, name, kwargs):
 
         salt-cloud -a rename mymachine newname=yourmachine
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -631,7 +631,7 @@ def rename(arg, name, kwargs):
     )
 
 
-def destroy(arg, name):
+def destroy(name, call=None):
     '''
     Wrap core libcloudfuncs destroy method, adding check for termination
     protection
@@ -646,11 +646,11 @@ def destroy(arg, name):
     pprint.pprint(result)
 
 
-def show_image(arg, kwargs):
+def show_image(kwargs, call=None):
     '''
     Show the details from EC2 concerning an AMI
     '''
-    if arg != 'function':
+    if call != 'function':
         print('This function must be called with -f or --function.')
         sys.exit(1)
 
@@ -661,11 +661,11 @@ def show_image(arg, kwargs):
     pprint.pprint(result)
 
 
-def show_instance(arg, name):
+def show_instance(name, call=None):
     '''
     Show the details from EC2 concerning an AMI
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -728,11 +728,11 @@ def list_nodes():
     return ret
 
 
-def show_term_protect(arg, name, instance_id=None):
+def show_term_protect(name, instance_id=None, call=None):
     '''
     Show the details from EC2 concerning an AMI
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -756,7 +756,7 @@ def show_term_protect(arg, name, instance_id=None):
         print('Termination Protection is disabled for {0}'.format(name))
 
 
-def enable_term_protect(arg, name):
+def enable_term_protect(name, call=None):
     '''
     Enable termination protection on a node
 
@@ -764,14 +764,14 @@ def enable_term_protect(arg, name):
 
         salt-cloud -a enable_term_protect mymachine
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
     _toggle_term_protect(name, 'true')
 
 
-def disable_term_protect(arg, name):
+def disable_term_protect(name, call=None):
     '''
     Disable termination protection on a node
 
@@ -779,7 +779,7 @@ def disable_term_protect(arg, name):
 
         salt-cloud -a disable_term_protect mymachine
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -492,10 +492,14 @@ def create_attach_volumes(volumes, location, data):
             )
 
 
-def stop(name):
+def stop(arg, name):
     '''
     Stop a node
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     log.info('Stopping node {0}'.format(name))
 
     instances = list_nodes_full()
@@ -508,10 +512,14 @@ def stop(name):
     pprint.pprint(result)
 
 
-def start(name):
+def start(arg, name):
     '''
     Start a node
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     log.info('Starting node {0}'.format(name))
 
     instances = list_nodes_full()
@@ -524,7 +532,7 @@ def start(name):
     pprint.pprint(result)
 
 
-def set_tags(name, tags):
+def set_tags(arg, name, tags):
     '''
     Set tags for a node
 
@@ -532,6 +540,10 @@ def set_tags(name, tags):
 
         salt-cloud -a set_tags mymachine tag1=somestuff tag2='Other stuff'
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     instances = list_nodes_full()
     instance_id = instances[name]['instanceId']
     params = {'Action': 'CreateTags',
@@ -549,10 +561,14 @@ def set_tags(name, tags):
     return get_tags(name)
 
 
-def get_tags(name):
+def get_tags(arg, name):
     '''
     Retrieve tags for a node
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     if ',' in name:
         names = name.split(',')
     else:
@@ -568,7 +584,7 @@ def get_tags(name):
     return result
 
 
-def del_tags(name, kwargs):
+def del_tags(arg, name, kwargs):
     '''
     Delete tags for a node
 
@@ -576,6 +592,10 @@ def del_tags(name, kwargs):
 
         salt-cloud -a del_tags mymachine tag1,tag2,tag3
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     instances = list_nodes_full()
     instance_id = instances[name]['instanceId']
     params = {'Action': 'DeleteTags',
@@ -588,7 +608,7 @@ def del_tags(name, kwargs):
     return get_tags(name)
 
 
-def rename(name, kwargs):
+def rename(arg, name, kwargs):
     '''
     Properly rename a node. Pass in the new name as "new name".
 
@@ -596,6 +616,10 @@ def rename(name, kwargs):
 
         salt-cloud -a rename mymachine newname=yourmachine
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     log.info('Renaming {0} to {1}'.format(name, kwargs['newname']))
 
     instances = list_nodes_full()
@@ -607,7 +631,7 @@ def rename(name, kwargs):
     )
 
 
-def destroy(name):
+def destroy(arg, name):
     '''
     Wrap core libcloudfuncs destroy method, adding check for termination
     protection
@@ -622,20 +646,29 @@ def destroy(name):
     pprint.pprint(result)
 
 
-def show_image(name, kwargs):
+def show_image(arg, kwargs):
     '''
     Show the details from EC2 concerning an AMI
     '''
+    if arg != 'function':
+        print('This function must be called with -f or --function.')
+        sys.exit(1)
+
     params = {'ImageId.1': kwargs['image'],
               'Action': 'DescribeImages'}
     result = query(params)
     log.info(result)
+    pprint.pprint(result)
 
 
-def show_instance(name):
+def show_instance(arg, name):
     '''
     Show the details from EC2 concerning an AMI
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     nodes = list_nodes_full()
     pprint.pprint(nodes[name])
     return nodes[name]
@@ -695,10 +728,14 @@ def list_nodes():
     return ret
 
 
-def show_term_protect(name, instance_id=None):
+def show_term_protect(arg, name, instance_id=None):
     '''
     Show the details from EC2 concerning an AMI
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     if not instance_id:
         instances = list_nodes_full()
         instance_id = instances[name]['instanceId']
@@ -719,7 +756,7 @@ def show_term_protect(name, instance_id=None):
         print('Termination Protection is disabled for {0}'.format(name))
 
 
-def enable_term_protect(name):
+def enable_term_protect(arg, name):
     '''
     Enable termination protection on a node
 
@@ -727,10 +764,14 @@ def enable_term_protect(name):
 
         salt-cloud -a enable_term_protect mymachine
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     _toggle_term_protect(name, 'true')
 
 
-def disable_term_protect(name):
+def disable_term_protect(arg, name):
     '''
     Disable termination protection on a node
 
@@ -738,6 +779,10 @@ def disable_term_protect(name):
 
         salt-cloud -a disable_term_protect mymachine
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     _toggle_term_protect(name, 'false')
 
 

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -120,11 +120,11 @@ def create(vm_):
         log.info('  {0}: {1}'.format(key, val))
 
 
-def stop(arg, name):
+def stop(name, call=None):
     '''
     Stop a node
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -120,10 +120,14 @@ def create(vm_):
         log.info('  {0}: {1}'.format(key, val))
 
 
-def stop(name):
+def stop(arg, name):
     '''
     Stop a node
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     conn = get_conn()
     node = get_node(conn, name)
     try:

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -363,10 +363,14 @@ def create_attach_volumes(volumes, location, data):
             )
 
 
-def stop(name):
+def stop(arg, name):
     '''
     Stop a node
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     location = get_location()
     conn = get_conn(location=location)
     node = get_node(conn, name)
@@ -379,10 +383,14 @@ def stop(name):
         log.error(exc)
 
 
-def start(name):
+def start(arg, name):
     '''
     Start a node
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     location = get_location()
     conn = get_conn(location=location)
     node = get_node(conn, name)
@@ -395,7 +403,7 @@ def start(name):
         log.error(exc)
 
 
-def set_tags(name, tags):
+def set_tags(arg, name, tags):
     '''
     Set tags for a node
 
@@ -403,6 +411,10 @@ def set_tags(name, tags):
 
         salt-cloud -a set_tags mymachine tag1=somestuff tag2='Other stuff'
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     location = get_location()
     conn = get_conn(location=location)
     node = get_node(conn, name)
@@ -420,10 +432,14 @@ def set_tags(name, tags):
         log.error(exc)
 
 
-def get_tags(name):
+def get_tags(arg, name):
     '''
     Retrieve tags for a node
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     location = get_location()
     conn = get_conn(location=location)
     node = get_node(conn, name)
@@ -436,7 +452,7 @@ def get_tags(name):
         log.error(exc)
 
 
-def del_tags(name, kwargs):
+def del_tags(arg, name, kwargs):
     '''
     Delete tags for a node
 
@@ -444,6 +460,10 @@ def del_tags(name, kwargs):
 
         salt-cloud -a del_tags mymachine tag1,tag2,tag3
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     location = get_location()
     conn = get_conn(location=location)
     node = get_node(conn, name)
@@ -462,7 +482,7 @@ def del_tags(name, kwargs):
         log.error(exc)
 
 
-def rename(name, kwargs):
+def rename(arg, name, kwargs):
     '''
     Properly rename a node. Pass in the new name as "new name".
 
@@ -470,6 +490,10 @@ def rename(name, kwargs):
 
         salt-cloud -a rename mymachine newname=yourmachine
     '''
+    if arg != 'action':
+        print('This action must be called with -a or --action.')
+        sys.exit(1)
+
     location = get_location()
     conn = get_conn(location=location)
     node = get_node(conn, name)

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -363,11 +363,11 @@ def create_attach_volumes(volumes, location, data):
             )
 
 
-def stop(arg, name):
+def stop(name, call=None):
     '''
     Stop a node
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -383,11 +383,11 @@ def stop(arg, name):
         log.error(exc)
 
 
-def start(arg, name):
+def start(name, call=None):
     '''
     Start a node
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -403,7 +403,7 @@ def start(arg, name):
         log.error(exc)
 
 
-def set_tags(arg, name, tags):
+def set_tags(name, tags, call=None):
     '''
     Set tags for a node
 
@@ -411,7 +411,7 @@ def set_tags(arg, name, tags):
 
         salt-cloud -a set_tags mymachine tag1=somestuff tag2='Other stuff'
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -432,11 +432,11 @@ def set_tags(arg, name, tags):
         log.error(exc)
 
 
-def get_tags(arg, name):
+def get_tags(name, call=None):
     '''
     Retrieve tags for a node
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -452,7 +452,7 @@ def get_tags(arg, name):
         log.error(exc)
 
 
-def del_tags(arg, name, kwargs):
+def del_tags(name, kwargs, call=None):
     '''
     Delete tags for a node
 
@@ -460,7 +460,7 @@ def del_tags(arg, name, kwargs):
 
         salt-cloud -a del_tags mymachine tag1,tag2,tag3
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 
@@ -482,7 +482,7 @@ def del_tags(arg, name, kwargs):
         log.error(exc)
 
 
-def rename(arg, name, kwargs):
+def rename(name, kwargs, call=None):
     '''
     Properly rename a node. Pass in the new name as "new name".
 
@@ -490,7 +490,7 @@ def rename(arg, name, kwargs):
 
         salt-cloud -a rename mymachine newname=yourmachine
     '''
-    if arg != 'action':
+    if call != 'action':
         print('This action must be called with -a or --action.')
         sys.exit(1)
 

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -149,68 +149,78 @@ class ExecutionOptionsMixIn(object):
         group.add_option(
             '-L', '--location',
             default='',
-            help='Specify which region to connect'
+            help='Specify which region to connect to.'
         )
         group.add_option(
             '-a', '--action',
             default='',
-            help=('Perform an action that may be specific to this cloud'
-                  'provider')
+            help=('Perform an action that may be specific to this cloud '
+                  'provider. This argument requires one or more instance '
+                  'names to be specified.')
+        )
+        group.add_option(
+            '-f', '--function',
+            default='',
+            help=('Perform an function that may be specific to this cloud '
+                  'provider, that does not apply to an instance. This argument '
+                  'requires a provider to be specified (i.e.: nova).')
         )
         group.add_option(
             '-p', '--profile',
             default='',
-            help='Specify a profile to use for the VMs'
+            help='Create an instance using the specified profile.'
         )
         group.add_option(
             '-m', '--map',
             default='',
-            help='Specify a cloud map file to use for deployment'
+            help='Specify a cloud map file to use for deployment. This option '
+                 'may be used alone, or in conjunction with -Q, -F, -S or -d.'
         )
         group.add_option(
             '-H', '--hard',
             default=False,
             action='store_true',
-            help='Delete all VMs that are not defined in the map file '
-                 'CAUTION!!! This operation can irrevocably destroy VMs!'
+            help='Delete all VMs that are not defined in the map file. '
+                 'CAUTION!!! This operation can irrevocably destroy VMs! It '
+                 'must be explicitly enabled in the cloud config file.'
         )
         group.add_option(
             '-d', '--destroy',
             default=False,
             action='store_true',
-            help='Specify a VM to destroy'
+            help='Destroy the specified instance(s).'
         )
         group.add_option(
             '--no-deploy',
             default=True,
             dest='deploy',
             action='store_false',
-            help='Don\'t run a deploy script after VM creation'
+            help='Don\'t run a deploy script after instance creation.'
         )
         group.add_option(
             '-P', '--parallel',
             default=False,
             action='store_true',
-            help='Build all of the specified virtual machines in parallel'
+            help='Build all of the specified instances in parallel.'
         )
         group.add_option(
             '-u', '--update-bootstrap',
             default=False,
             action='store_true',
             help='Update salt-bootstrap to the latest develop version on '
-                 'GitHub'
+                 'GitHub.'
         )
         group.add_option(
             '-y', '--assume-yes',
             default=False,
             action='store_true',
-            help='Default yes in answer to all confirmation questions'
+            help='Default yes in answer to all confirmation questions.'
         )
         group.add_option(
-            '--keep-tmp',
+            '-k', '--keep-tmp',
             default=False,
             action='store_true',
-            help='Do not remove files from /tmp/ after deploy.sh finishes'
+            help='Do not remove files from /tmp/ after deploy.sh finishes.'
         )
         self.add_option_group(group)
 


### PR DESCRIPTION
This changes the way that -a/--action is handled internally, and keeps -f/--function functions from being called by -a, and keeps actions from being called by -f.

Sample usage for this style looks like:

```
salt-cloud -f ec2 show_image image=ami-fd20ad94
```

If such a function were to be called with --action, an instance name would be required to make the call, but not used.
