### PR TITLE
The `--function` parser option now expects two arguments.

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -89,7 +89,6 @@ class SaltCloud(parsers.SaltCloudParser):
                     )
             salt.output.display_output(query_map, '', self.config)
 
-
         if self.options.list_locations is not None:
             try:
                 saltcloud.output.double_layer(
@@ -191,26 +190,26 @@ class SaltCloud(parsers.SaltCloudParser):
             self.exit(0)
 
         if self.options.function:
-            prov = self.config.get('function', None)
+            prov_func = '{0}.{1}'.format(
+                self.function_provider, self.function_name
+            )
+            if prov_func not in mapper.clouds:
+                self.error(
+                    'The {0!r} provider does not define the function '
+                    '{1!r}'.format(
+                        self.function_provider, self.function_name
+                    )
+                )
 
-            names = self.config.get('names', None)
-            func = ''
             kwargs = {}
+            for arg in self.args:
+                if '=' in arg:
+                    key, value = arg.split('=')
+                    kwargs[key] = value
 
-            if not names:
-                self.error('Not enough arguments were given.')
-
-            for name in names:
-                if '=' in name:
-                    comps = name.split('=')
-                    kwargs[comps[0]] = comps[1]
-                else:
-                    func = name
-
-            if not func:
-                self.error('A function name was not specified.')
-
-            mapper.do_function(prov, func, kwargs)
+            mapper.do_function(
+                self.function_provider, self.function_name, kwargs
+            )
             self.exit(0)
 
         if self.options.profile and self.config.get('names', False):

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -303,7 +303,6 @@ class Cloud(object):
                     name, self.opts['action'])
                 )
 
-
     def do_function(self, prov, func, kwargs):
         '''
         Perform an action which may be specific to this cloud provider

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -160,10 +160,11 @@ class ExecutionOptionsMixIn(object):
         )
         group.add_option(
             '-f', '--function',
+            nargs=2,
             default='',
             help=('Perform an function that may be specific to this cloud '
-                  'provider, that does not apply to an instance. This argument '
-                  'requires a provider to be specified (i.e.: nova).')
+                  'provider, that does not apply to an instance. This '
+                  'argument requires a provider to be specified (i.e.: nova).')
         )
         group.add_option(
             '-p', '--profile',
@@ -223,6 +224,10 @@ class ExecutionOptionsMixIn(object):
             help='Do not remove files from /tmp/ after deploy.sh finishes.'
         )
         self.add_option_group(group)
+
+    def process_function(self):
+        if self.options.function:
+            self.function_provider, self.function_name = self.options.function
 
 
 class CloudQueriesMixIn(object):

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -162,6 +162,7 @@ class ExecutionOptionsMixIn(object):
             '-f', '--function',
             nargs=2,
             default='',
+            metavar='<PROVIDER> <FUNC-NAME>',
             help=('Perform an function that may be specific to this cloud '
                   'provider, that does not apply to an instance. This '
                   'argument requires a provider to be specified (i.e.: nova).')
@@ -228,6 +229,11 @@ class ExecutionOptionsMixIn(object):
     def process_function(self):
         if self.options.function:
             self.function_provider, self.function_name = self.options.function
+            if self.function_name.startswith('-') or '=' in self.function_name:
+                self.error(
+                    '--function expects two arguments: <provider> '
+                    '<function-name>'
+                )
 
 
 class CloudQueriesMixIn(object):


### PR DESCRIPTION
- Additionally we fail if the desired provider does not implement the function we want.
