### PR TITLE
Sync after install

### DIFF
--- a/doc/topics/misc.rst
+++ b/doc/topics/misc.rst
@@ -22,3 +22,26 @@ the following line needs to be added to the main cloud configuration file:
 
     delete_sshkeys: True
 
+Sync After Install
+==================
+
+Salt allows users to create custom modules, grains and states which can be 
+synchronised to minions to extend Salt with further functionality.
+
+This option will inform Salt Cloud to synchronise your custom modules, grains,
+states or all these to the minion just after it has been created. For this to 
+happen, the following line needs to be added to the main cloud 
+configuration file:
+
+.. code-block:: yaml
+
+    sync_after_install: all
+
+The available options for this setting are:
+
+.. code-block:: yaml
+
+    modules
+    grains
+    states
+    all

--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -222,10 +222,14 @@ class SaltCloud(parsers.SaltCloudParser):
 
         if self.config.get('map', None) and self.selected_query_option is None:
             if len(mapper.map) == 0:
-                print('Nothing to do')
+                print('No nodes defined in this map')
                 self.exit(0)
             try:
                 dmap = mapper.map_data()
+                if 'destroy' not in dmap and len(dmap['create']) == 0:
+                    print('All nodes in this map already exist')
+                    self.exit(0)
+
                 log.info('Applying map from {0!r}.'.format(self.config['map']))
 
                 msg = 'The following virtual machines are set to be created:\n'
@@ -239,6 +243,8 @@ class SaltCloud(parsers.SaltCloudParser):
 
                 if self.print_confirm(msg):
                     mapper.run_map(dmap)
+
+                log.info('Complete')
             except Exception as exc:
                 log.debug('There was a query error.', exc_info=True)
                 self.error('There was a query error: {0}'.format(exc))


### PR DESCRIPTION
This is a small feature that's been useful for me on AWS - it will get salt-cloud to synchronise any custom grains/modules/states over to a minion right after create.

It came about because I needed the ec2_info grain available right after a minion was deployed - before waiting for highstate to run.
