### PR TITLE
Allow EC2 driver to use salt outputter

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -177,9 +177,10 @@ class SaltCloud(parsers.SaltCloudParser):
                     machines.append(name)
             names = machines
 
+            ret = {}
             try:
                 if self.print_confirm(msg):
-                    mapper.do_action(names, kwargs)
+                    ret = mapper.do_action(names, kwargs)
             except Exception as exc:
                 log.debug(
                     'There was a error actioning machines.', exc_info=True
@@ -187,6 +188,8 @@ class SaltCloud(parsers.SaltCloudParser):
                 self.error(
                     'There was an error actioning machines: {0}'.format(exc)
                 )
+
+            salt.output.display_output(ret, '', self.config)
             self.exit(0)
 
         if self.options.function:
@@ -213,14 +216,19 @@ class SaltCloud(parsers.SaltCloudParser):
             self.exit(0)
 
         if self.options.profile and self.config.get('names', False):
+            ret = {}
+
             try:
-                mapper.run_profile()
+                ret = mapper.run_profile()
             except Exception as exc:
                 log.debug('There was a profile error.', exc_info=True)
                 self.error('There was a profile error: {0}'.format(exc))
+
+            salt.output.display_output(ret, '', self.config)
             self.exit(0)
 
         if self.config.get('map', None) and self.selected_query_option is None:
+            ret = {}
             if len(mapper.map) == 0:
                 print('No nodes defined in this map')
                 self.exit(0)
@@ -242,7 +250,7 @@ class SaltCloud(parsers.SaltCloudParser):
                         msg += '  {0}\n'.format(name)
 
                 if self.print_confirm(msg):
-                    mapper.run_map(dmap)
+                    ret = mapper.run_map(dmap)
 
                 if self.config.get('parallel', False) == False:
                     log.info('Complete')
@@ -250,6 +258,8 @@ class SaltCloud(parsers.SaltCloudParser):
             except Exception as exc:
                 log.debug('There was a query error.', exc_info=True)
                 self.error('There was a query error: {0}'.format(exc))
+
+            salt.output.display_output(ret, '', self.config)
             self.exit(0)
 
     def print_confirm(self, msg):

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -29,7 +29,6 @@ import sys
 import stat
 import time
 import logging
-import pprint
 
 # Import libs for talking to the EC2 API
 import hmac
@@ -649,11 +648,14 @@ def create(vm_=None, call=None):
     log.info(
         'Created Cloud VM {name} with the following values:'.format(**vm_)
     )
-    pprint.pprint(data[0]['instancesSet']['item'])
+    ret = (data[0]['instancesSet']['item'])
+
     volumes = vm_.get('map_volumes')
     if volumes:
         log.info('Create and attach volumes to node {0}'.format(data.name))
         create_attach_volumes(volumes, location, data)
+
+    return ret
 
 
 def create_attach_volumes(volumes, location, data):
@@ -695,7 +697,7 @@ def stop(name, call=None):
               'InstanceId.1': instance_id}
     result = query(params)
 
-    pprint.pprint(result)
+    return result
 
 
 def start(name, call=None):
@@ -715,7 +717,7 @@ def start(name, call=None):
               'InstanceId.1': instance_id}
     result = query(params)
 
-    pprint.pprint(result)
+    return result
 
 
 def set_tags(name, tags, call=None):
@@ -766,7 +768,7 @@ def get_tags(name, call=None):
               'Filter.1.Name': 'resource-id',
               'Filter.1.Value': instance_id}
     result = query(params, setname='tagSet')
-    pprint.pprint(result)
+
     return result
 
 
@@ -791,6 +793,7 @@ def del_tags(name, kwargs, call=None):
         params['Tag.{0}.Key'.format(count)] = tag
         count += 1
     result = query(params, setname='tagSet')
+
     return get_tags(name)
 
 
@@ -840,7 +843,8 @@ def destroy(name, call=None):
               'InstanceId.1': instance_id}
     result = query(params)
     log.info(result)
-    pprint.pprint(result)
+
+    return result
 
 
 def reboot(name, call=None):
@@ -859,6 +863,8 @@ def reboot(name, call=None):
     if result == []:
         log.info("Complete")
 
+    return {'Reboot': 'Complete'}
+
 
 def show_image(kwargs, call=None):
     '''
@@ -872,7 +878,8 @@ def show_image(kwargs, call=None):
               'Action': 'DescribeImages'}
     result = query(params)
     log.info(result)
-    pprint.pprint(result)
+
+    return result
 
 
 def show_instance(name, call=None):
@@ -884,7 +891,7 @@ def show_instance(name, call=None):
         sys.exit(1)
 
     nodes = list_nodes_full()
-    pprint.pprint(nodes[name])
+
     return nodes[name]
 
 
@@ -919,6 +926,7 @@ def list_nodes_full():
             ret[name]['private_ips'].append(instance['instancesSet']['item']['privateIpAddress'])
         if 'ipAddress' in instance['instancesSet']['item']:
             ret[name]['public_ips'].append(instance['instancesSet']['item']['ipAddress'])
+
     return ret
 
 
@@ -957,6 +965,7 @@ def list_nodes_select():
                 value = data[key]
                 pairs[key] = value
         ret[node] = pairs
+
     return ret
 
 
@@ -1007,7 +1016,7 @@ def enable_term_protect(name, call=None):
               '-a or --action.')
         sys.exit(1)
 
-    _toggle_term_protect(name, 'true')
+    return _toggle_term_protect(name, 'true')
 
 
 def disable_term_protect(name, call=None):
@@ -1023,7 +1032,7 @@ def disable_term_protect(name, call=None):
               '-a or --action.')
         sys.exit(1)
 
-    _toggle_term_protect(name, 'false')
+    return _toggle_term_protect(name, 'false')
 
 
 def _toggle_term_protect(name, value):
@@ -1041,7 +1050,7 @@ def _toggle_term_protect(name, value):
               'DisableApiTermination.Value': value}
     result = query(params, return_root=True)
 
-    show_term_protect(name, instance_id, call='action')
+    return show_term_protect(name, instance_id, call='action')
 
 
 def keepvol_on_destroy(name, call=None):
@@ -1057,7 +1066,7 @@ def keepvol_on_destroy(name, call=None):
               '-a or --action.')
         sys.exit(1)
 
-    _toggle_delvol(name=name, value='false')
+    return _toggle_delvol(name=name, value='false')
 
 
 def delvol_on_destroy(name, call=None):
@@ -1073,7 +1082,7 @@ def delvol_on_destroy(name, call=None):
               '-a or --action.')
         sys.exit(1)
 
-    _toggle_delvol(name=name, value='true')
+    return _toggle_delvol(name=name, value='true')
 
 
 def _toggle_delvol(name=None, instance_id=None, value=None, requesturl=None):
@@ -1104,5 +1113,5 @@ def _toggle_delvol(name=None, instance_id=None, value=None, requesturl=None):
               'BlockDeviceMapping.1.Ebs.DeleteOnTermination': value}
     result = query(params, return_root=True)
 
-    pprint.pprint(query(requesturl=requesturl))
+    return query(requesturl=requesturl)
 


### PR DESCRIPTION
This will cause all output from EC2 to be returned through the salt outputter, and enable all other cloud providers to do the same thing.
