### PR TITLE
CLI mods

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -96,6 +96,7 @@ class SaltCloud(parsers.SaltCloudParser):
                             exc
                         )
                     )
+                    self.exit(1)
             else:
                 try:
                     query_map = mapper.map_providers(
@@ -106,6 +107,7 @@ class SaltCloud(parsers.SaltCloudParser):
                     self.error(
                         'There was an error with a map: {0}'.format(exc)
                     )
+                    self.exit(1)
             salt.output.display_output(query_map, '', self.config)
 
         if self.options.list_locations is not None:
@@ -120,6 +122,7 @@ class SaltCloud(parsers.SaltCloudParser):
                 self.error(
                     'There was an error listing locations: {0}'.format(exc)
                 )
+                self.exit(1)
             self.exit(0)
 
         if self.options.list_images is not None:
@@ -132,6 +135,7 @@ class SaltCloud(parsers.SaltCloudParser):
                 self.error(
                     'There was an error listing images: {0}'.format(exc)
                 )
+                self.exit(1)
             self.exit(0)
 
         if self.options.list_sizes is not None:
@@ -144,6 +148,7 @@ class SaltCloud(parsers.SaltCloudParser):
                 self.error(
                     'There was an error listing sizes: {0}'.format(exc)
                 )
+                self.exit(1)
             self.exit(0)
 
         if self.options.destroy and (self.config.get('names', None) or
@@ -170,6 +175,8 @@ class SaltCloud(parsers.SaltCloudParser):
                 self.error(
                     'There was an error destroy machines: {0}'.format(exc)
                 )
+                self.exit(1)
+
             salt.output.display_output(ret, '', self.config)
             self.exit(0)
 
@@ -210,6 +217,7 @@ class SaltCloud(parsers.SaltCloudParser):
                 self.error(
                     'There was an error actioning machines: {0}'.format(exc)
                 )
+                self.exit(1)
 
             salt.output.display_output(ret, '', self.config)
             self.exit(0)
@@ -246,6 +254,7 @@ class SaltCloud(parsers.SaltCloudParser):
             except Exception as exc:
                 log.debug('There was a profile error.', exc_info=True)
                 self.error('There was a profile error: {0}'.format(exc))
+                self.exit(1)
 
             salt.output.display_output(ret, '', self.config)
             self.exit(0)
@@ -254,12 +263,12 @@ class SaltCloud(parsers.SaltCloudParser):
             ret = {}
             if len(mapper.map) == 0:
                 print('No nodes defined in this map')
-                self.exit(0)
+                self.exit(1)
             try:
                 dmap = mapper.map_data()
                 if 'destroy' not in dmap and len(dmap['create']) == 0:
                     print('All nodes in this map already exist')
-                    self.exit(0)
+                    self.exit(1)
 
                 log.info('Applying map from {0!r}.'.format(self.config['map']))
 
@@ -281,6 +290,7 @@ class SaltCloud(parsers.SaltCloudParser):
             except Exception as exc:
                 log.debug('There was a query error.', exc_info=True)
                 self.error('There was a query error: {0}'.format(exc))
+                self.exit(1)
 
             salt.output.display_output(ret, '', self.config)
             self.exit(0)

--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -231,9 +231,18 @@ class SaltCloud(parsers.SaltCloudParser):
                     key, value = arg.split('=')
                     kwargs[key] = value
 
-            ret = mapper.do_function(
-                self.function_provider, self.function_name, kwargs
-            )
+            try:
+                ret = mapper.do_function(
+                    self.function_provider, self.function_name, kwargs
+                )
+            except Exception as exc:
+                log.debug(
+                    'There was a error running the function.', exc_info=True
+                )
+                self.error(
+                    'There was an error running the function: {0}'.format(exc)
+                )
+                self.exit(1)
 
         elif self.options.profile and self.config.get('names', False):
             try:

--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -86,7 +86,7 @@ class SaltCloud(parsers.SaltCloudParser):
             if self.config.get('map', None):
                 log.info('Applying map from {0!r}.'.format(self.config['map']))
                 try:
-                    query_map = mapper.interpolated_map(
+                    ret = mapper.interpolated_map(
                         query=self.selected_query_option
                     )
                 except Exception as exc:
@@ -101,7 +101,7 @@ class SaltCloud(parsers.SaltCloudParser):
                     self.exit(1)
             else:
                 try:
-                    query_map = mapper.map_providers(
+                    ret = mapper.map_providers(
                         query=self.selected_query_option
                     )
                 except Exception as exc:
@@ -111,9 +111,7 @@ class SaltCloud(parsers.SaltCloudParser):
                     )
                     self.exit(1)
 
-            salt.output.display_output(query_map, '', self.config)
-
-        if self.options.list_locations is not None:
+        elif self.options.list_locations is not None:
             try:
                 saltcloud.output.double_layer(
                     mapper.location_list(self.options.list_locations)

--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -80,6 +80,8 @@ class SaltCloud(parsers.SaltCloudParser):
             with salt.utils.fopen(deploy_path, 'w') as fp_:
                 fp_.write(req.read())
 
+        ret = {}
+
         if self.selected_query_option is not None:
             if self.config.get('map', None):
                 log.info('Applying map from {0!r}.'.format(self.config['map']))
@@ -108,6 +110,7 @@ class SaltCloud(parsers.SaltCloudParser):
                         'There was an error with a map: {0}'.format(exc)
                     )
                     self.exit(1)
+
             salt.output.display_output(query_map, '', self.config)
 
         if self.options.list_locations is not None:
@@ -123,9 +126,8 @@ class SaltCloud(parsers.SaltCloudParser):
                     'There was an error listing locations: {0}'.format(exc)
                 )
                 self.exit(1)
-            self.exit(0)
 
-        if self.options.list_images is not None:
+        elif self.options.list_images is not None:
             try:
                 saltcloud.output.double_layer(
                     mapper.image_list(self.options.list_images)
@@ -136,9 +138,8 @@ class SaltCloud(parsers.SaltCloudParser):
                     'There was an error listing images: {0}'.format(exc)
                 )
                 self.exit(1)
-            self.exit(0)
 
-        if self.options.list_sizes is not None:
+        elif self.options.list_sizes is not None:
             try:
                 saltcloud.output.double_layer(
                     mapper.size_list(self.options.list_sizes)
@@ -149,12 +150,9 @@ class SaltCloud(parsers.SaltCloudParser):
                     'There was an error listing sizes: {0}'.format(exc)
                 )
                 self.exit(1)
-            self.exit(0)
 
-        if self.options.destroy and (self.config.get('names', None) or
-                                     self.config.get('map', None)):
-            ret = {}
-
+        elif self.options.destroy and (self.config.get('names', None) or
+                                       self.config.get('map', None)):
             if self.config.get('map', None):
                 log.info('Applying map from {0!r}.'.format(self.config['map']))
                 names = mapper.delete_map(query='list_nodes')
@@ -177,11 +175,8 @@ class SaltCloud(parsers.SaltCloudParser):
                 )
                 self.exit(1)
 
-            salt.output.display_output(ret, '', self.config)
-            self.exit(0)
-
-        if self.options.action and (self.config.get('names', None) or
-                                    self.config.get('map', None)):
+        elif self.options.action and (self.config.get('names', None) or
+                                      self.config.get('map', None)):
             if self.config.get('map', None):
                 log.info('Applying map from {0!r}.'.format(self.config['map']))
                 names = mapper.delete_map(query='list_nodes')
@@ -206,7 +201,6 @@ class SaltCloud(parsers.SaltCloudParser):
                     machines.append(name)
             names = machines
 
-            ret = {}
             try:
                 if self.print_confirm(msg):
                     ret = mapper.do_action(names, kwargs)
@@ -219,10 +213,7 @@ class SaltCloud(parsers.SaltCloudParser):
                 )
                 self.exit(1)
 
-            salt.output.display_output(ret, '', self.config)
-            self.exit(0)
-
-        if self.options.function:
+        elif self.options.function:
             prov_func = '{0}.{1}'.format(
                 self.function_provider, self.function_name
             )
@@ -243,12 +234,8 @@ class SaltCloud(parsers.SaltCloudParser):
             ret = mapper.do_function(
                 self.function_provider, self.function_name, kwargs
             )
-            salt.output.display_output(ret, '', self.config)
-            self.exit(0)
 
-        if self.options.profile and self.config.get('names', False):
-            ret = {}
-
+        elif self.options.profile and self.config.get('names', False):
             try:
                 ret = mapper.run_profile()
             except Exception as exc:
@@ -256,11 +243,7 @@ class SaltCloud(parsers.SaltCloudParser):
                 self.error('There was a profile error: {0}'.format(exc))
                 self.exit(1)
 
-            salt.output.display_output(ret, '', self.config)
-            self.exit(0)
-
-        if self.config.get('map', None) and self.selected_query_option is None:
-            ret = {}
+        elif self.config.get('map', None) and self.selected_query_option is None:
             if len(mapper.map) == 0:
                 print('No nodes defined in this map')
                 self.exit(1)
@@ -292,8 +275,9 @@ class SaltCloud(parsers.SaltCloudParser):
                 self.error('There was a query error: {0}'.format(exc))
                 self.exit(1)
 
-            salt.output.display_output(ret, '', self.config)
-            self.exit(0)
+        # display output using salt's outputter system
+        salt.output.display_output(ret, '', self.config)
+        self.exit(0)
 
     def print_confirm(self, msg):
         if self.options.assume_yes:


### PR DESCRIPTION
Previously we use exits all over to break the flow in the cli module. I believe this patch is a better solution!

Comments please.

Changes:
- correct exit codes on error
- refactored to use and if-else block, so we only exit on success in one place
- changed query option to be exclusive of other options; the same as others in the list (this the only functionality change; look at bbbd10c)
