### PR TITLE
Outputter changes

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -283,7 +283,7 @@ class SaltCloud(parsers.SaltCloudParser):
                 self.exit(1)
 
         # display output using salt's outputter system
-        salt.output.display_output(ret, '', self.config)
+        salt.output.display_output(ret, self.options.output, self.config)
         self.exit(0)
 
     def print_confirm(self, msg):

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -228,7 +228,7 @@ class Cloud(object):
         try:
             output = self.clouds['{0}.create'.format(self.provider(vm_))](vm_)
 
-            if 'sync_after_install' in self.opts:
+            if output is not False and 'sync_after_install' in self.opts:
                 if self.opts['sync_after_install'] not in (
                     'all', 'modules', 'states', 'grains'):
                     log.error('Bad option for sync_after_install')

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -471,7 +471,7 @@ class Map(Cloud):
         '''
         Execute the contents of the VM map
         '''
-        # We are good to go, execute!
+        output = {}
         # Generate the fingerprint of the master pubkey in
         #     order to mitigate man-in-the-middle attacks
         master_pub = self.opts['pki_dir'] + '/master.pub'
@@ -496,6 +496,7 @@ class Map(Cloud):
                     target=lambda: self.create(tvm)
                 ).start()
             else:
-                self.create(tvm)
+                output[name] = self.create(tvm)
         for name in dmap.get('destroy', set()):
-            self.destroy(name)
+            output[name] = self.destroy(name)
+        return output


### PR DESCRIPTION
- Now using the output from create to indicate success for the sync_after_install option 
- Output some results create/destroy with a map
- Use the salt command line options for format our output!
