### PR TITLE
Add volume management to ec2

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -1194,3 +1194,27 @@ def attach_volume(name=None, kwargs=None, instance_id=None, call=None):
 
     data = query(params, return_root=True)
     return data
+
+
+def detach_volume(name=None, kwargs=None, instance_id=None, call=None):
+    '''
+    Detach a volume from an instance
+    '''
+    if call != 'action':
+        log.error('The attach_volume action must be called with '
+                  '-a or --action.')
+        sys.exit(1)
+
+    if not kwargs:
+        kwargs = {}
+
+    if not 'volume_id' in kwargs:
+        log.error('A volume_id is required.')
+        return False
+
+    params = {'Action': 'DetachVolume',
+              'VolumeId': kwargs['volume_id']}
+
+    data = query(params, return_root=True)
+    return data
+

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -1196,12 +1196,30 @@ def attach_volume(name=None, kwargs=None, instance_id=None, call=None):
     return data
 
 
+def show_volume(name=None, kwargs=None, instance_id=None, call=None):
+    '''
+    Show volume details
+    '''
+    if not kwargs:
+        kwargs = {}
+
+    if not 'volume_id' in kwargs:
+        log.error('A volume_id is required.')
+        return False
+
+    params = {'Action': 'DescribeVolumes',
+              'VolumeId.1': kwargs['volume_id']}
+
+    data = query(params, return_root=True)
+    return data
+
+
 def detach_volume(name=None, kwargs=None, instance_id=None, call=None):
     '''
     Detach a volume from an instance
     '''
     if call != 'action':
-        log.error('The attach_volume action must be called with '
+        log.error('The detach_volume action must be called with '
                   '-a or --action.')
         sys.exit(1)
 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -1236,3 +1236,21 @@ def detach_volume(name=None, kwargs=None, instance_id=None, call=None):
     data = query(params, return_root=True)
     return data
 
+
+def delete_volume(name=None, kwargs=None, instance_id=None, call=None):
+    '''
+    Delete a volume
+    '''
+    if not kwargs:
+        kwargs = {}
+
+    if not 'volume_id' in kwargs:
+        log.error('A volume_id is required.')
+        return False
+
+    params = {'Action': 'DeleteVolume',
+              'VolumeId': kwargs['volume_id']}
+
+    data = query(params, return_root=True)
+    return data
+

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -1154,3 +1154,43 @@ def create_volume(kwargs=None, call=None):
 
     data = query(params, return_root=True)
     return data
+
+
+def attach_volume(name=None, kwargs=None, instance_id=None, call=None):
+    '''
+    Attach a volume to an instance
+    '''
+    if call != 'action':
+        log.error('The attach_volume action must be called with '
+                  '-a or --action.')
+        sys.exit(1)
+
+    if not kwargs:
+        kwargs = {}
+
+    if 'instance_id' in kwargs:
+        instance_id = kwargs['instance_id']
+
+    if name and not instance_id:
+        instances = list_nodes_full()
+        instance_id = instances[name]['instanceId']
+
+    if not name and not instance_id:
+        log.error('Either a name or an instance_id is required.')
+        return False
+
+    if not 'volume_id' in kwargs:
+        log.error('A volume_id is required.')
+        return False
+
+    if not 'device' in kwargs:
+        log.error('A device is required (ex. /dev/sdb1).')
+        return False
+
+    params = {'Action': 'AttachVolume',
+              'VolumeId': kwargs['volume_id'],
+              'InstanceId': instance_id,
+              'Device': kwargs['device']}
+
+    data = query(params, return_root=True)
+    return data


### PR DESCRIPTION
The only one of these that requires a VM name or instance_id is attach_volume(), which also requires a volume_id. create_volume() requires an availability zone (zone), and either a size in GiB (default 10) or a snapshot id (snapshot) to make a copy of. show_volume, detach_volume and delete_volume only require a volume_id.
