### PR TITLE
Fixed wait_for_ssh to prevent invalid socket state

### DIFF
--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -186,20 +186,23 @@ def wait_for_ssh(host, port=22, timeout=900):
     Wait until an ssh connection can be made on a specified host
     '''
     start = time.time()
+    log.debug('Attempting SSH connection to host {0} on port {1}'.format(host, port))
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     trycount = 0
     while True:
         trycount += 1
         try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect((host, port))
             sock.shutdown(2)
             return True
-        except Exception:
+        except Exception as e:
+            log.debug('Caught exception in wait_for_ssh: {0}'.format(e))
             time.sleep(1)
-            log.debug('Retrying SSH connection (try {0})'.format(trycount))
             if time.time() - start > timeout:
                 log.error('SSH connection timed out: {0}'.format(timeout))
                 return False
+            log.debug('Retrying SSH connection (try {0})'.format(trycount))
 
 
 def wait_for_passwd(host, port=22, ssh_timeout=15, username='root',
@@ -420,7 +423,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
 
 def scp_file(dest_path, contents, kwargs):
     '''
-    Use scp to copy a file to a server    
+    Use scp to copy a file to a server
     '''
     tmpfh, tmppath = tempfile.mkstemp()
     tmpfile = open(tmppath, 'w')

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -187,7 +187,6 @@ def wait_for_ssh(host, port=22, timeout=900):
     '''
     start = time.time()
     log.debug('Attempting SSH connection to host {0} on port {1}'.format(host, port))
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     trycount = 0
     while True:
         trycount += 1


### PR DESCRIPTION
My attempts to provision EC2 VMs were failing at the SSH step; meanwhile I had no trouble connecting to them directly using parameters identical to those I was giving salt-cloud.

After adding debug output to wait_for_ssh, I saw the following:

```
[DEBUG   ] Attempting to connect to host <correct ec2 ip address> on port 22
[ERROR   ] Error connecting to SSH: [Errno 61] Connection refused
[DEBUG   ] Retrying SSH connection (try 1)
[ERROR   ] Error connecting to SSH: [Errno 22] Invalid argument
[DEBUG   ] Retrying SSH connection (try 2)
[ERROR   ] Error connecting to SSH: [Errno 22] Invalid argument
[DEBUG   ] Retrying SSH connection (try 3)
[ERROR   ] Error connecting to SSH: [Errno 22] Invalid argument
...
[DEBUG   ] Retrying SSH connection (try 350)
[ERROR   ] Error connecting to SSH: [Errno 22] Invalid argument
```

I'm no expert on python's socket module but obvious hypothesis was after first (entirely normal) error, socket enters an invalid state and -- because sock is initialized outside of the while loop -- is never properly reset. So I just moved `sock =` inside the try block. And that fixed it.

Also, I think it's a good idea to leave in these log.debug statements as I suspect SSH is a common source of baffling issues. 
