### PR TITLE
Allow specifying the deploy value from the `vm` profile.

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -130,7 +130,7 @@ if hasattr(Provider, 'EC2_AP_SOUTHEAST2'):
 
 
 def _xml_to_dict(xmltree):
-    ''' 
+    '''
     Convert an XML tree into a dict
     '''
     if len(xmltree.getchildren()) < 1:
@@ -619,7 +619,7 @@ def create(vm_=None, call=None):
     if 'sudo' in vm_.keys():
         sudo = vm_['sudo']
 
-    if __opts__['deploy'] is True:
+    if vm_.get('deploy', __opts__['deploy']) is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
             'host': ip_address,
@@ -855,7 +855,7 @@ def destroy(name, call=None):
     if protected == 'true':
         log.error('This instance has been protected from being destroyed. '
                   'Use the following command to disable protection:\n\n'
-                  'salt-cloud -a disable_term_protect {0}'.format(name)) 
+                  'salt-cloud -a disable_term_protect {0}'.format(name))
         exit(1)
 
     params = {'Action': 'TerminateInstances',

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -98,7 +98,8 @@ def create(vm_):
         sys.stderr.write(err)
         log.error(err)
         return False
-    if __opts__['deploy'] is True:
+
+    if vm_.get('deploy', __opts__['deploy']) is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
             'host': data.public_ips[0],

--- a/saltcloud/clouds/ibmsce.py
+++ b/saltcloud/clouds/ibmsce.py
@@ -128,7 +128,7 @@ def create(vm_):
             not_ready = False
         time.sleep(15)
 
-    if __opts__['deploy'] is True:
+    if vm_.get('deploy', __opts__['deploy']) is True:
         deploy_script = script(vm_)
         log.debug(
             'Deploying {0} using IP address {1}'.format(

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -88,7 +88,7 @@ def create(vm_):
                        )
         log.error(err)
         return False
-    if __opts__['deploy'] is True:
+    if vm_.get('deploy', __opts__['deploy']) is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
             'host': data.public_ips[0],

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -305,7 +305,7 @@ def create(vm_):
     if 'sudo' in vm_.keys():
         sudo = vm_['sudo']
 
-    if __opts__['deploy'] is True:
+    if vm_.get('deploy', __opts__['deploy']) is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
             'host': ip_address,
@@ -560,15 +560,20 @@ def destroy(name):
     from saltcloud.libcloudfuncs import destroy as libcloudfuncs_destroy
     location = get_location()
     conn = get_conn(location=location)
-    libcloudfuncs_destroy = namespaced_function(libcloudfuncs_destroy, globals(), (conn,))
+    libcloudfuncs_destroy = namespaced_function(
+        libcloudfuncs_destroy, globals(), (conn,)
+    )
     try:
         result = libcloudfuncs_destroy(name, conn)
         ret[name] = result
     except Exception as e:
         if e.message.startswith('OperationNotPermitted'):
-            log.info('Failed: termination protection is enabled on {0}'.format(name))
+            log.info(
+                'Failed: termination protection is enabled on {0}'.format(
+                    name
+                )
+            )
         else:
             raise e
 
     return ret
-

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -118,7 +118,7 @@ def create(vm_):
         log.error(err)
         return False
 
-    if __opts__['deploy'] is True:
+    if vm_.get('deploy', __opts__['deploy']) is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
             'host': data.public_ips[0],
@@ -138,15 +138,25 @@ def create(vm_):
         if 'script_args' in vm_:
             deploy_kwargs['script_args'] = vm_['script_args']
 
-        deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
+        deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(
+            __opts__, vm_
+        )
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
         else:
-            log.error('Failed to start Salt on Cloud VM {0}'.format(vm_['name']))
+            log.error(
+                'Failed to start Salt on Cloud VM {0}'.format(
+                    vm_['name']
+                )
+            )
 
     ret = {}
-    log.info('Created Cloud VM {0} with the following values:'.format(vm_['name']))
+    log.info(
+        'Created Cloud VM {0} with the following values:'.format(
+            vm_['name']
+        )
+    )
     for key, val in data.__dict__.items():
         ret[key] = val
         log.info('  {0}: {1}'.format(key, val))

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -141,9 +141,16 @@ def preferred_ip(vm_, ips):
 
 def ssh_interface(vm_):
     '''
-    Return the ssh_interface type to connect to. Either 'public_ips' (default) or 'private_ips'.
+    Return the ssh_interface type to connect to. Either 'public_ips' (default)
+    or 'private_ips'.
     '''
-    return vm_.get('ssh_interface', __opts__.get('OPENSTACK.ssh_interface', 'public_ips'))
+    return vm_.get(
+        'ssh_interface',
+        __opts__.get(
+            'OPENSTACK.ssh_interface',
+            'public_ips'
+        )
+    )
 
 
 def create(vm_):
@@ -201,7 +208,8 @@ def create(vm_):
         public = nodelist[vm_['name']]['public_ips']
         running = nodelist[vm_['name']]['state'] == node_state(NodeState.RUNNING)
         if running and private and not public:
-            log.warn('Private IPs returned, but not public... checking for misidentified IPs')
+            log.warn('Private IPs returned, but not public... checking for '
+                     'misidentified IPs')
             for private_ip in private:
                 private_ip = preferred_ip(vm_, [private_ip])
                 if saltcloud.utils.is_public_ip(private_ip):
@@ -247,7 +255,10 @@ def create(vm_):
     if 'script_args' in vm_:
         deploy_kwargs['script_args'] = vm_['script_args']
 
-    deployargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
+    deployargs['minion_conf'] = saltcloud.utils.minion_conf_string(
+        __opts__,
+        vm_
+    )
     if 'ssh_username' in vm_:
         deployargs['deploy_command'] = '/tmp/deploy.sh'
         deployargs['username'] = vm_['ssh_username']
@@ -258,7 +269,11 @@ def create(vm_):
 
     if 'OPENSTACK.ssh_key_file' in __opts__:
         deployargs['key_filename'] = __opts__['OPENSTACK.ssh_key_file']
-        log.debug('Using {0} as SSH key file'.format(deployargs['key_filename']))
+        log.debug(
+            'Using {0} as SSH key file'.format(
+                deployargs['key_filename']
+            )
+        )
     elif 'password' in data.extra:
         deployargs['password'] = data.extra['password']
         log.debug('Logging into SSH using password')
@@ -267,7 +282,7 @@ def create(vm_):
         deployargs['sudo'] = vm_['sudo']
         log.debug('Running root commands using sudo')
 
-    if __opts__['deploy'] is True:
+    if vm_.get('deploy', __opts__['deploy']) is True:
         deploy_script = script(vm_)
         deployargs['script'] = deploy_script.script
 
@@ -275,10 +290,18 @@ def create(vm_):
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
         else:
-            log.error('Failed to start Salt on Cloud VM {0}'.format(vm_['name']))
+            log.error(
+                'Failed to start Salt on Cloud VM {0}'.format(
+                    vm_['name']
+                )
+            )
 
     ret = {}
-    log.info('Created Cloud VM {0} with the following values:'.format(vm_['name']))
+    log.info(
+        'Created Cloud VM {0} with the following values:'.format(
+            vm_['name']
+        )
+    )
     for key, val in data.__dict__.items():
         ret[key] = val
         log.info('  {0}: {1}'.format(key, val))

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -171,7 +171,7 @@ def create(vm_):
     if not ip_address:
         raise
 
-    if __opts__['deploy'] is True:
+    if vm_.get('deploy', __opts__['deploy']) is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
             'host': ip_address,


### PR DESCRIPTION
Now, the `vm` deploy value is grabbed initially from the `vm` profile, and if not set, grab the value from `__opts__`.

I got the idea that this was supported from @cedwards presentation slides. If it was supported, that support got lost and this pull request fixes it.

Should we also check if the could provider has a "global" `deploy` setting too?

``` python
vm_.get('deploy', __opts__.get('<provider>.deploy', __opts__['deploy'])) is True
```
