### PR TITLE
Address #403: Allow map to create master and associated minions

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -545,7 +545,8 @@ class Map(Cloud):
         for miniondict in self.map[tvm['profile']]:
             if isinstance(miniondict, dict) and name in miniondict:
                 for option in option_types:
-                    tvm['map_{0}'.format(option)] = miniondict[name][option]
+                    if option in miniondict[name]:
+                        tvm['map_{0}'.format(option)] = miniondict[name][option]
         return tvm
 
 

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -484,25 +484,41 @@ class Map(Cloud):
         output = {}
         if self.opts['parallel']:
             parallel_data = []
+        master_name = None
+        master_host = None
+        try:
+            master_name, master_profile = ((name, profile) for name, profile in
+                dmap['create'].items() if 'make_master' in profile and
+                profile['make_master'] is True).next()
+            log.debug('Creating new master {0}'.format(master_name))
+            tvm = self.vm_options(master_name, master_profile, None, ['grains', 'volumes'])
+            out = self.create(tvm)
+            if 'deploy_kwargs' in out and 'host' in out['deploy_kwargs']:
+                master_host = out['deploy_kwargs']['host']
+                output[master_name] = out
+            else:
+                print('Host for new master {0} was not found, '
+                    'aborting map'.format(master_name))
+                sys.exit(1)
+        except StopIteration:
+            log.debug('No make_master found in map')
+
         # Generate the fingerprint of the master pubkey in
         #     order to mitigate man-in-the-middle attacks
         master_pub = self.opts['pki_dir'] + '/master.pub'
         master_finger = ''
         if os.path.isfile(master_pub) and hasattr(salt.utils, 'pem_finger'):
             master_finger = salt.utils.pem_finger(master_pub)
+
+        option_types = ['grains', 'minion', 'volumes']
         for name, profile in dmap['create'].items():
-            tvm = copy.deepcopy(profile)
-            tvm['name'] = name
-            tvm['master_finger'] = master_finger
-            for miniondict in self.map[tvm['profile']]:
-                if isinstance(miniondict, dict):
-                    if name in miniondict:
-                        if 'grains' in miniondict[name]:
-                            tvm['map_grains'] = miniondict[name]['grains']
-                        if 'minion' in miniondict[name]:
-                            tvm['map_minion'] = miniondict[name]['minion']
-                        if 'volumes' in miniondict[name]:
-                            tvm['map_volumes'] = miniondict[name]['volumes']
+            if master_name and name is master_name:
+                continue
+            if 'minion' not in profile:
+                profile['minion'] = {}
+            if master_host and 'master' not in profile['minion']:
+                profile['minion']['master'] = master_host
+            tvm = self.vm_options(name, profile, master_finger, option_types)
             if self.opts['parallel']:
                 parallel_data.append({
                     'opts': self.opts,
@@ -522,10 +538,20 @@ class Map(Cloud):
                 output.update(obj)
         return output
 
+    def vm_options(self, name, profile, master_finger, option_types):
+        tvm = copy.deepcopy(profile)
+        tvm['name'] = name
+        tvm['master_finger'] = master_finger
+        for miniondict in self.map[tvm['profile']]:
+            if isinstance(miniondict, dict) and name in miniondict:
+                for option in option_types:
+                    tvm['map_{0}'.format(option)] = miniondict[name][option]
+        return tvm
+
 
 def create_multiprocessing(config):
     """
-    This function will be called from another process when running a map in 
+    This function will be called from another process when running a map in
     parallel mode. The result from the create is always a json object.
     """
     config['opts']['output'] = 'json'

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -649,6 +649,7 @@ def create(vm_=None, call=None):
     if 'sudo' in vm_.keys():
         sudo = vm_['sudo']
 
+    ret = {}
     deploy = vm_.get('deploy', __opts__.get('EC2.deploy', __opts__['deploy']))
     if deploy is True:
         deploy_script = script(vm_)
@@ -696,13 +697,14 @@ def create(vm_=None, call=None):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {name}'.format(**vm_))
+            ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error('Failed to start Salt on Cloud VM {name}'.format(**vm_))
 
     log.info(
         'Created Cloud VM {name} with the following values:'.format(**vm_)
     )
-    ret = (data[0]['instancesSet']['item'])
+    ret.update(data[0]['instancesSet']['item'])
 
     volumes = vm_.get('map_volumes')
     if volumes:

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -106,6 +106,7 @@ def create(vm_):
             __opts__['deploy']
         )
     )
+    ret = {}
     if deploy is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
@@ -145,6 +146,7 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
+            ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(
@@ -152,7 +154,6 @@ def create(vm_):
                 )
             )
 
-    ret = {}
     log.info(
         'Created Cloud VM {0} with the following values:'.format(
             vm_['name']

--- a/saltcloud/clouds/ibmsce.py
+++ b/saltcloud/clouds/ibmsce.py
@@ -135,6 +135,7 @@ def create(vm_):
             __opts__['deploy']
         )
     )
+    ret = {}
     if deploy is True:
         deploy_script = script(vm_)
         log.debug(
@@ -182,12 +183,12 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
+            ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(vm_['name'])
             )
 
-    ret = {}
     log.info(
         'Created Cloud VM {0} with the following values:'.format(vm_['name'])
     )

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -96,6 +96,7 @@ def create(vm_):
             __opts__['deploy']
         )
     )
+    ret = {}
     if deploy is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
@@ -137,6 +138,7 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
+            ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(
@@ -144,7 +146,6 @@ def create(vm_):
                 )
             )
 
-    ret = {}
     log.info(
         'Created Cloud VM {0} with the following values:'.format(
             vm_['name']

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -306,6 +306,7 @@ def create(vm_):
     if 'sudo' in vm_.keys():
         sudo = vm_['sudo']
 
+    ret = {}
     deploy = vm_.get('deploy', __opts__.get('AWS.deploy', __opts__['deploy']))
     if deploy is True:
         deploy_script = script(vm_)
@@ -350,13 +351,13 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {name}'.format(**vm_))
+            ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error('Failed to start Salt on Cloud VM {name}'.format(**vm_))
 
     log.info(
         'Created Cloud VM {name} with the following values:'.format(**vm_)
     )
-    ret = {}
     for key, val in data.__dict__.items():
         ret[key] = val
         log.debug('  {0}: {1}'.format(key, val))

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -125,6 +125,7 @@ def create(vm_):
             __opts__['deploy']
         )
     )
+    ret = {}
     if deploy is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
@@ -165,6 +166,7 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
+            ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(
@@ -172,7 +174,6 @@ def create(vm_):
                 )
             )
 
-    ret = {}
     log.info(
         'Created Cloud VM {0} with the following values:'.format(
             vm_['name']

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -178,6 +178,7 @@ def create(vm_):
             __opts__['deploy']
         )
     )
+    ret = {}
     if deploy is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
@@ -217,6 +218,7 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
+            ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(
@@ -224,7 +226,6 @@ def create(vm_):
                 )
             )
 
-    ret = {}
     log.info(
         'Created Cloud VM {0} with the following values:'.format(
             vm_['name']

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -152,7 +152,7 @@ def minion_conf_string(opts, vm_):
         minion['master_finger'] = vm_['master_finger']
     minion.update(opts.get('minion', {}))
     minion.update(vm_.get('minion', {}))
-    if 'master' not in minion:
+    if 'master' not in minion and 'make_master' not in vm_:
         raise ValueError("A master was not defined.")
     minion.update(opts.get('map_minion', {}))
     minion.update(vm_.get('map_minion', {}))
@@ -454,7 +454,7 @@ def root_cmd(command, tty, sudo, **kwargs):
     '''
     if sudo:
         command = 'sudo ' + command
-        log.debug('Using sudo to run command')
+        log.debug('Using sudo to run command {0}'.format(command))
 
     ssh_args = ' -oStrictHostKeyChecking=no'
     ssh_args += ' -oUserKnownHostsFile=/dev/null'


### PR DESCRIPTION
When a make_master is present in a map, it's created first and used as the minion.master for any minions in the map lacking that attribute.

Unnecessary log output and inadvertently included bootstrap file removed.
