### PR TITLE
Fix problems of not using location(ec2 region) defined in a VM profile during create()

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -165,8 +165,8 @@ def _xml_to_dict(xmltree):
     return xmldict
 
 
-def query(params=None, setname=None, requesturl=None, return_url=False,
-          return_root=False):
+def query(params=None, setname=None, requesturl=None, location=None,
+          return_url=False, return_root=False):
     key = __opts__['EC2.key']
     keyid = __opts__['EC2.id']
     if 'EC2.service_url' in __opts__:
@@ -175,8 +175,10 @@ def query(params=None, setname=None, requesturl=None, return_url=False,
         service_url = 'amazonaws.com'
     timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
 
-    if not requesturl:
+    if not location:
         location = get_location()
+
+    if not requesturl:
         method = 'GET'
 
         if 'EC2.endpoint' in __opts__:
@@ -381,7 +383,7 @@ def script(vm_):
     minion = saltcloud.utils.minion_conf_string(__opts__, vm_)
     script = saltcloud.utils.os_script(
         saltcloud.utils.get_option(
-            'os',
+            'script',
             __opts__,
             vm_
         ),
@@ -410,24 +412,15 @@ def securitygroup(vm_):
 
 def ssh_username(vm_):
     '''
-    Return the ssh_username. Defaults to 'ec2-user'.
+    Return the ssh_username. Defaults to a built-in list of users for trying.
     '''
-    usernames = vm_.get(
-        'ssh_username', __opts__.get('EC2.ssh_username', 'ec2-user')
-    )
+    usernames = vm_.get('ssh_username', __opts__.get('EC2.ssh_username', []))
     if not isinstance(usernames, list):
-        username = usernames
-        usernames = [username]
-    if not 'ec2-user' in usernames:
-        usernames.append('ec2-user')
-    if not 'ubuntu' in usernames:
-        usernames.append('ubuntu')
-    if not 'admin' in usernames:
-        usernames.append('admin')
-    if not 'bitnami' in usernames:
-        usernames.append('bitnami')
-    if not 'root' in usernames:
-        usernames.append('root')
+        usernames = [usernames]
+    usernames = filter(lambda x: x, usernames) # get rid of None's or empty names
+    for name in 'ec2-user ubuntu admin bitnami root'.split():
+        if name not in usernames:
+            usernames.append(name)
     return usernames
 
 
@@ -578,7 +571,7 @@ def create(vm_=None, call=None):
         ).lower()
 
     try:
-        data = query(params, 'instancesSet')
+        data = query(params, 'instancesSet', location=location)
         if 'error' in data:
             return data['error']
     except Exception as exc:
@@ -591,13 +584,13 @@ def create(vm_=None, call=None):
         return False
 
     instance_id = data[0]['instanceId']
-    set_tags(instance_id, {'Name': vm_['name']}, call='action')
+    set_tags(instance_id, {'Name': vm_['name']}, call='action', location=location)
     log.info('Created node {0}'.format(vm_['name']))
     waiting_for_ip = 0
 
     params = {'Action': 'DescribeInstances',
               'InstanceId.1': instance_id}
-    data, requesturl = query(params, return_url=True)
+    data, requesturl = query(params, location=location, return_url=True)
 
     while 'ipAddress' not in data[0]['instancesSet']['item']:
         log.debug('Salt node waiting for IP {0}'.format(waiting_for_ip))
@@ -774,7 +767,7 @@ def start(name, call=None):
     return result
 
 
-def set_tags(name, tags, call=None):
+def set_tags(name, tags, call=None, location=None):
     '''
     Set tags for a node
 
@@ -786,7 +779,7 @@ def set_tags(name, tags, call=None):
         log.error('The set_tags action must be called with -a or --action.')
         sys.exit(1)
 
-    instances = list_nodes_full()
+    instances = list_nodes_full(location)
     instance_id = instances[name]['instanceId']
     params = {'Action': 'CreateTags',
               'ResourceId.1': instance_id}
@@ -795,15 +788,12 @@ def set_tags(name, tags, call=None):
         params['Tag.{0}.Key'.format(count)] = tag
         params['Tag.{0}.Value'.format(count)] = tags[tag]
         count += 1
-    result = query(params, setname='tagSet')
+    result = query(params, setname='tagSet', location=location)
 
-    if 'Name' in tags:
-        return get_tags(tags['Name'], call='action')
-
-    return get_tags(name, call='action')
+    return get_tags(name, call='action', location=location)
 
 
-def get_tags(name, call=None):
+def get_tags(name, call=None, location=None):
     '''
     Retrieve tags for a node
     '''
@@ -816,14 +806,14 @@ def get_tags(name, call=None):
     else:
         names = [name]
 
-    instances = list_nodes_full()
-    instance_id = instances[name]['instanceId']
-    params = {'Action': 'DescribeTags',
-              'Filter.1.Name': 'resource-id',
-              'Filter.1.Value': instance_id}
-    result = query(params, setname='tagSet')
-
-    return result
+    instances = list_nodes_full(location)
+    if name in instances:
+        instance_id = instances[name]['instanceId']
+        params = {'Action': 'DescribeTags',
+                  'Filter.1.Name': 'resource-id',
+                  'Filter.1.Value': instance_id}
+        return query(params, setname='tagSet', location=location)
+    return []
 
 
 def del_tags(name, kwargs, call=None):
@@ -960,14 +950,33 @@ def show_instance(name, call=None):
     return nodes[name]
 
 
-def list_nodes_full():
+def list_nodes_full(location=None):
     '''
     Return a list of the VMs that are on the provider
     '''
-    ret = {}
+    if not location:
+        ret = {}
+        locations = set(
+            get_location(vm_) for vm_ in __opts__['vm']
+                              if _vm_provider(vm_)=='ec2'
+        )
+        for loc in locations:
+            ret.update(_list_nodes_full(loc))
+        return ret
+    else:
+        return _list_nodes_full(location)
 
+
+def _vm_provider(vm_):
+    return vm_.get('provider', __opts__['provider'])
+
+
+def _list_nodes_full(location=None):
+    ret = {}
     params = {'Action': 'DescribeInstances'}
-    instances = query(params)
+    instances = query(params, location=location)
+#    import pprint
+#    pprint.pprint(instances)
 
     for instance in instances:
         if 'tagSet' in instance['instancesSet']['item']:
@@ -995,7 +1004,6 @@ def list_nodes_full():
         if 'ipAddress' in instance['instancesSet']['item']:
             ret[name]['public_ips'].append(
                         instance['instancesSet']['item']['ipAddress'])
-
     return ret
 
 
@@ -1004,7 +1012,6 @@ def list_nodes():
     Return a list of the VMs that are on the provider
     '''
     ret = {}
-
     nodes = list_nodes_full()
     for node in nodes:
         ret[node] = {
@@ -1015,7 +1022,6 @@ def list_nodes():
             'private_ips': nodes[node]['private_ips'],
             'public_ips': nodes[node]['public_ips'],
         }
-
     return ret
 
 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -975,8 +975,6 @@ def _list_nodes_full(location=None):
     ret = {}
     params = {'Action': 'DescribeInstances'}
     instances = query(params, location=location)
-#    import pprint
-#    pprint.pprint(instances)
 
     for instance in instances:
         if 'tagSet' in instance['instancesSet']['item']:

--- a/saltcloud/deploy/curl-bootstrap-git.sh
+++ b/saltcloud/deploy/curl-bootstrap-git.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
-
+# bootstrap-salt <-- magic string needed to disguise as the salt-bootstrap script.
+#
 # This is a generic wrapper for the salt-bootstrap script at:
 #
 # https://github.com/saltstack/salt-bootstrap
 # 
 # It has been designed as an example, to be customized for your own needs.
 
-curl -L http://bootstrap.saltstack.org | sudo sh -s -- -c /tmp git develop
+curl -L http://bootstrap.saltstack.org | sudo sh -s -- "$@" git develop
 
 # Salt Cloud now places the minion's keys and configuration in /tmp/ before
 # executing the deploy script. After it has executed, these temporary files

--- a/saltcloud/deploy/curl-bootstrap.sh
+++ b/saltcloud/deploy/curl-bootstrap.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
-
+# bootstrap-salt <-- magic string needed to disguise as the salt-bootstrap script.
+#
 # This is a generic wrapper for the salt-bootstrap script at:
 #
 # https://github.com/saltstack/salt-bootstrap
 # 
 # It has been designed as an example, to be customized for your own needs.
 
-curl -L http://bootstrap.saltstack.org | sudo sh -s -- -c /tmp
+curl -L http://bootstrap.saltstack.org | sudo sh -s -- "$@"
 
 # Salt Cloud now places the minion's keys and configuration in /tmp/ before
 # executing the deploy script. After it has executed, these temporary files

--- a/saltcloud/deploy/python-bootstrap.sh
+++ b/saltcloud/deploy/python-bootstrap.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# bootstrap-salt <-- magic string needed to disguise as the salt-bootstrap script.
 
 # This is a generic wrapper for the salt-bootstrap script at:
 #
@@ -6,7 +7,7 @@
 # 
 # It has been designed as an example, to be customized for your own needs.
 
-python -c 'import urllib; print urllib.urlopen("http://bootstrap.saltstack.org").read()' | sudo sh -s -- -c /tmp
+python -c 'import urllib; print urllib.urlopen("http://bootstrap.saltstack.org").read()' | sudo sh -s -- "$@"
 
 # Salt Cloud now places the minion's keys and configuration in /tmp/ before
 # executing the deploy script. After it has executed, these temporary files

--- a/saltcloud/deploy/wget-bootstrap-nocert.sh
+++ b/saltcloud/deploy/wget-bootstrap-nocert.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# bootstrap-salt <-- magic string needed to disguise as the salt-bootstrap script.
 
 # This is a generic wrapper for the salt-bootstrap script at:
 #
@@ -6,7 +7,7 @@
 # 
 # It has been designed as an example, to be customized for your own needs.
 
-wget --no-check-certificate -O - http://bootstrap.saltstack.org | sudo sh -s -- -c /tmp
+wget --no-check-certificate -O - http://bootstrap.saltstack.org | sudo sh -s -- "$@"
 
 # Salt Cloud now places the minion's keys and configuration in /tmp/ before
 # executing the deploy script. After it has executed, these temporary files

--- a/saltcloud/deploy/wget-bootstrap.sh
+++ b/saltcloud/deploy/wget-bootstrap.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# bootstrap-salt <-- magic string needed to disguise as the salt-bootstrap script.
 
 # This is a generic wrapper for the salt-bootstrap script at:
 #
@@ -6,7 +7,7 @@
 # 
 # It has been designed as an example, to be customized for your own needs.
 
-wget -O - http://bootstrap.saltstack.org | sudo sh -s -- -c /tmp
+wget -O - http://bootstrap.saltstack.org | sudo sh -s -- "$@"
 
 # Salt Cloud now places the minion's keys and configuration in /tmp/ before
 # executing the deploy script. After it has executed, these temporary files

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -287,12 +287,15 @@ def deploy_script(host, port=22, timeout=900, username='root',
             elif password:
                 log.debug('Using {0} as the password'.format(password))
                 kwargs['password'] = password
+
+            #FIXME: this try-except idoesn't make sense! something is missing...
             try:
                 log.debug('SSH connection to {0} successful'.format(host))
             except Exception as exc:
                 log.error(
                     'There was an error in deploy_script: {0}'.format(exc)
                 )
+
             if provider == 'ibmsce':
                 subsys_command = (
                     'sed -i "s/#Subsystem/Subsystem/" '
@@ -322,7 +325,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
             # The actual deploy script
             if script:
                 scp_file('/tmp/deploy.sh', script, kwargs)
-            root_cmd('chmod +x /tmp/deploy.sh', tty, sudo, **kwargs)
+                root_cmd('chmod +x /tmp/deploy.sh', tty, sudo, **kwargs)
 
             newtimeout = timeout - (time.mktime(time.localtime()) - starttime)
             queue = None
@@ -342,12 +345,12 @@ def deploy_script(host, port=22, timeout=900, username='root',
             # Run the deploy script
             if script:
                 log.debug('Executing /tmp/deploy.sh')
-                if make_syndic:
-                    deploy_command += ' -S'
-                if make_master:
-                    deploy_command += ' -M'
                 if 'bootstrap-salt' in script:
-                    deploy_command += ' -c /tmp/'
+                    deploy_command += ' -c /tmp/'  #FIXME: always?
+                    if make_syndic:
+                        deploy_command += ' -S'
+                    if make_master:
+                        deploy_command += ' -M'
                 if script_args:
                     deploy_command += ' {0}'.format(script_args)
 


### PR DESCRIPTION
Tried salt-cloud with a fresh git clone, didn't work for me. These are the fixes that I had to make it work with my `cloud` and `cloud.profiles` configs. Basically, I'm using the `ec2` provider with a VM profile that specifies a location override:

<pre>
master:
  provider: ec2
  image: ami-be1230fb
  size: Micro Instance
  location: us-west-1
  ssh_username: ubuntu
  script: wget-bootstrap
  make_master: True
  minion:
    master: 127.0.0.1
    grains:
      cheese: edam
</pre>

I only did this for the ec2 provider, the `aws` provider might also have the same problem.
Please review and merge whatever that makes sense to you as I'm not yet familiar with the code base yet. Thanks!
