### PR TITLE
Update create_attach_volumes() in EC2 to use direct API

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -115,9 +115,6 @@ def __virtual__():
             )
         )
 
-    # open a connection in a specific region
-    conn = get_conn(**{'location': get_location()})
-
     log.debug('Loading EC2 cloud compute module')
     return 'ec2'
 
@@ -393,29 +390,6 @@ def script(vm_):
         minion,
     )
     return script
-
-
-def get_conn(**kwargs):
-    '''
-    Return a conn object for the passed VM data
-    '''
-    if 'location' in kwargs:
-        location = kwargs['location']
-        if location not in EC2_LOCATIONS:
-            raise SaltException(
-                'The specified location does not seem to be valid: '
-                '{0}\n'.format(
-                    location
-                )
-            )
-    else:
-        location = DEFAULT_LOCATION
-
-    driver = get_driver(EC2_LOCATIONS[location])
-    return driver(
-        __opts__['EC2.id'],
-        __opts__['EC2.key'],
-    )
 
 
 def keyname(vm_):

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -682,8 +682,6 @@ def create(vm_=None, call=None):
     volumes = vm_.get('map_volumes')
     if volumes:
         log.info('Create and attach volumes to node {0}'.format(vm_['name']))
-        import pprint
-        pprint.pprint(ret['placement']['availabilityZone'])
         created = create_attach_volumes(vm_['name'],
                               {'volumes': volumes,
                                'zone': ret['placement']['availabilityZone'],


### PR DESCRIPTION
This removes the final vestiges of libcloud support from this driver. If a user would like to use libcloud, the AWS driver still uses it.
