### PR TITLE
Check if the 'append_domain' option is set before accepting the key.

### DIFF
--- a/doc/man/salt-cloud.7
+++ b/doc/man/salt-cloud.7
@@ -462,10 +462,12 @@ minions that are created derive their configuration.
 .ft C
 minion:
     master: saltmaster.example.com
+    append_domain: example.com
 .ft P
 .fi
 .sp
-This is the location in particular to specify the location of the salt master.
+This example specifies the location of the salt master, and explicitly sets the
+domain name in case automatic detection fails.
 .SS Cloud Configurations
 .sp
 The data specific to interacting with public clouds is set up here.

--- a/doc/topics/profiles.rst
+++ b/doc/topics/profiles.rst
@@ -25,6 +25,7 @@ public cloud provider. A number of additional parameters can also be inserted:
         script: RHEL6
         minion:
             master: salt.example.com
+            append_domain: webs.example.com
         grains:
             role: webserver
 

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -179,6 +179,13 @@ class Cloud(object):
                 delret = self.clouds[fun](name)
                 ret.append(delret)
                 if delret:
+                    key_id = name
+                    minion_dict = saltcloud.utils.get_option(
+                            'minion',
+                            self.opts,
+                            self.opts['vm'])
+                    if 'append_domain' in minion_dict:
+                        key_id = '.'.join([key_id, minion_dict['append_domain']])
                     saltcloud.utils.remove_key(self.opts['pki_dir'], name)
 
         return ret

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -234,7 +234,12 @@ class Cloud(object):
         if 'script' in vm_:
             vm_['os'] = vm_['script']
 
-        saltcloud.utils.accept_key(self.opts['pki_dir'], pub, vm_['name'])
+        key_id = vm_['name']
+        minion_dict = saltcloud.utils.get_option('minion', self.opts, vm_)
+        if 'append_domain' in minion_dict:
+            key_id = '.'.join([key_id, minion_dict['append_domain']])
+        saltcloud.utils.accept_key(self.opts['pki_dir'], pub, key_id)
+
         try:
             output = self.clouds['{0}.create'.format(self.provider(vm_))](vm_)
 


### PR DESCRIPTION
If the minion is configured with the 'append_domain' option, then we need to add that string to the key name before accepting the generated key for the minion.  Otherwise, when the minion starts it will generate a new key request which needs to be manually accepted, and a stale accepted request will go unused.
