### PR TITLE
Fail soon when no master is set

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -212,8 +212,13 @@ class Cloud(object):
         '''
         output = {}
 
-        if 'minion' in vm_ and vm_['minion'] is None:
+        if 'minion' not in vm_:
+            # Let's grab a global minion configuration if defined
+            vm_['minion'] = self.opts.get('minion', {})
+        elif 'minion' in vm_ and vm_['minion'] is None:
+            # Let's set a sane, empty, default
             vm_['minion'] = {}
+
         fun = '{0}.create'.format(self.provider(vm_))
         if fun not in self.clouds:
             log.error(
@@ -230,9 +235,9 @@ class Cloud(object):
             )
         )
 
-        if deploy is True and 'master' not in vm_['minion']:
+        if deploy is True and 'master' not in vm_.get('minion', ()):
             raise ValueError(
-                'There\'s no master defined in the {0} VM settings'.format(
+                'There\'s no master defined on the {0!r} VM settings'.format(
                     vm_['name']
                 )
             )

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -223,6 +223,20 @@ class Cloud(object):
             )
             return
 
+        deploy = vm_.get(
+            'deploy', self.opts.get(
+                '{0}.deploy'.format(self.provider(vm_).upper()),
+                self.opts.get('deploy')
+            )
+        )
+
+        if deploy is True and 'master' not in vm_['minion']:
+            raise ValueError(
+                'There\'s no master defined in the {0} VM settings'.format(
+                    vm_['name']
+                )
+            )
+
         priv, pub = saltcloud.utils.gen_keys(
             saltcloud.utils.get_option('keysize', self.opts, vm_)
         )
@@ -535,7 +549,7 @@ class Map(Cloud):
 
 def create_multiprocessing(config):
     """
-    This function will be called from another process when running a map in 
+    This function will be called from another process when running a map in
     parallel mode. The result from the create is always a json object.
     """
     config['opts']['output'] = 'json'

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -4,7 +4,6 @@ Utility functions for saltcloud
 
 # Import python libs
 import os
-import sys
 import shutil
 import socket
 import tempfile
@@ -22,6 +21,7 @@ log = logging.getLogger(__name__)
 # Import salt libs
 import salt.crypt
 import salt.client
+import salt.config
 import salt.utils
 from salt.exceptions import SaltException
 
@@ -166,7 +166,11 @@ def minion_conf_string(opts, vm_):
     Return a string to be passed into the deployment script for the minion
     configuration file
     '''
-    minion = {'id': vm_['name']}
+    # Let's get a copy of the salt minion default options
+    minion = salt.config.DEFAULT_MINION_OPTS.copy()
+
+    # Now, let's update it to our needs
+    minion['id'] = vm_['name']
     if 'master_finger' in vm_:
         minion['master_finger'] = vm_['master_finger']
     minion.update(opts.get('minion', {}))
@@ -189,7 +193,9 @@ def master_conf_string(opts, vm_):
     Return a string to be passed into the deployment script for the master
     configuration file
     '''
-    master = {}
+
+    # Let's get a copy of the salt master default options
+    master = salt.config.DEFAULT_MASTER_OPTS.copy()
 
     master.update(opts.get('master', {}))
     master.update(vm_.get('master', {}))

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -9,7 +9,6 @@ import socket
 import tempfile
 import time
 import subprocess
-import salt.utils.event
 import multiprocessing
 import logging
 import types
@@ -23,6 +22,7 @@ import salt.crypt
 import salt.client
 import salt.config
 import salt.utils
+import salt.utils.event
 from salt.exceptions import SaltException
 
 # Import third party libs


### PR DESCRIPTION
- Start minion and master configuration with their respective defaults.
- Fail as soon as we realize we're deploying and master was not specificed anywhere in the configuration.
-  Fix `KeyError` and don't forget the cloud configuration. Use any `minion` settings defined in the cloud configuration file if not defined in the VM's configuration.
