### PR TITLE
A few bug fixes:

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -242,8 +242,8 @@ class SaltCloud(parsers.SaltCloudParser):
 
         elif self.options.function:
             prov_func = '{0}.{1}'.format(
-                self.function_name,
                 self.function_provider,
+                self.function_name
             )
             if prov_func not in mapper.clouds:
                 self.error(
@@ -261,7 +261,7 @@ class SaltCloud(parsers.SaltCloudParser):
 
             try:
                 ret = mapper.do_function(
-                    self.function_provider, self.function_name, kwargs
+                    self.function_name, self.function_provider, kwargs
                 )
             except Exception as exc:
                 log.debug(
@@ -272,7 +272,10 @@ class SaltCloud(parsers.SaltCloudParser):
                 )
                 self.exit(1)
 
-        elif self.options.profile and self.config.get('names', False):
+        elif self.options.profile:
+            if not self.config.get('names'):
+                self.error('Please supply the names for the instances to be created!')
+                self.exit(1)
             try:
                 ret = mapper.run_profile()
             except Exception as exc:

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -184,9 +184,9 @@ class Cloud(object):
                             'minion',
                             self.opts,
                             self.opts['vm'])
-                    if 'append_domain' in minion_dict:
+                    if minion_dict and 'append_domain' in minion_dict:
                         key_id = '.'.join([key_id, minion_dict['append_domain']])
-                    saltcloud.utils.remove_key(self.opts['pki_dir'], name)
+                    saltcloud.utils.remove_key(self.opts['pki_dir'], key_id)
 
         return ret
 
@@ -262,7 +262,7 @@ class Cloud(object):
 
         key_id = vm_['name']
         minion_dict = saltcloud.utils.get_option('minion', self.opts, vm_)
-        if 'append_domain' in minion_dict:
+        if minion_dict and 'append_domain' in minion_dict:
             key_id = '.'.join([key_id, minion_dict['append_domain']])
         saltcloud.utils.accept_key(self.opts['pki_dir'], pub, key_id)
 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -1027,7 +1027,7 @@ def _list_nodes_full(location=None):
     return ret
 
 
-def list_nodes():
+def list_nodes(call=None):
     '''
     Return a list of the VMs that are on the provider
     '''

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -228,7 +228,7 @@ class ExecutionOptionsMixIn(object):
 
     def process_function(self):
         if self.options.function:
-            self.function_provider, self.function_name = self.options.function
+            self.function_name, self.function_provider = self.options.function
             if self.function_name.startswith('-') or '=' in self.function_name:
                 self.error(
                     '--function expects two arguments: <provider> '


### PR DESCRIPTION
- Fix incorrect ordering of arguments to the -f option.
  BTW, personally, I think using this format:
  
  ```
  -f &lt;provider&gt;.&lt;function&gt; [name1=value name2=value2 ...]
  ```
  
  makes more sense than the current format:
  
  ```
  -f &lt;function&gt; &lt;provider&gt; [name1=value name2=value2 ...]
  ```
  
  but anyways.
- Give better error message when -p <profile_name> is used but no instance
  names are supplied.
- Make ec2's list_node() also available for use with the -f option.
- Fix the incorrect assumption that a minion dict will always be
  available in the config when removing minion keys from master.
  It's possible that the node is a salt-master node created by the
  make_master option.
