### PR TITLE
Switch to `urllib2`. Sometimes `urllib` returns `None` when calling `getcode()`

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -63,9 +63,9 @@ class SaltCloud(parsers.SaltCloudParser):
         self.setup_logfile_logger()
 
         if self.options.update_bootstrap:
-            import urllib
+            import urllib2
             url = 'http://bootstrap.saltstack.org'
-            req = urllib.urlopen(url)
+            req = urllib2.urlopen(url)
             if req.getcode() != 200:
                 self.error(
                     'Failed to download the latest stable version of the '

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ The setup script for salt
 '''
 
 import os
-import urllib
+import urllib2
 from distutils import log
 from distutils.core import setup
 from distutils.command.build import build as distutils_build
@@ -56,7 +56,7 @@ class build(distutils_build):
                 BOOTSTRAP_SCRIPT_DISTRIBUTED_VERSION
             )
         )
-        req = urllib.urlopen(url)
+        req = urllib2.urlopen(url)
         deploy_path = os.path.join(
             SALTCLOUD_SOURCE_DIR, 'saltcloud', 'deploy', 'bootstrap-salt.sh'
         )


### PR DESCRIPTION
Switch to `urllib2`. Sometimes `urllib` returns `None` when calling `getcode()`
