### PR TITLE
EC2 instance provisioning is incomplete and does not set Name tag (https://github.com/saltstack/salt-cloud/issues/478)

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -1015,26 +1015,26 @@ def _list_nodes_full(location=None):
 
     for instance in instances:
         # items could be type dict or list (for stopped EC2 instances)
-	if isinstance(instance['instancesSet']['item'], list):
-	    for item in instance['instancesSet']['item']:
-		name = _extract_name_tag(item)
-		ret[name] = item
-		ret[name].update(dict(id=item['instanceId'], 
-				 image=item['imageId'], 
-				 size=item['instanceType'], 
-				 state=item['instanceState']['name'], 
-				 private_ips=item.get('privateIpAddress', []), 
-				 public_ips=item.get('ipAddress', [])))
-	else:
-	    item = instance['instancesSet']['item']
-	    name = _extract_name_tag(item)
-	    ret[name] = item
-	    ret[name].update(dict(id=item['instanceId'], 
-			     image=item['imageId'], 
-			     size=item['instanceType'], 
-			     state=item['instanceState']['name'], 
-			     private_ips=item.get('privateIpAddress', []), 
-			     public_ips=item.get('ipAddress', [])))
+        if isinstance(instance['instancesSet']['item'], list):
+            for item in instance['instancesSet']['item']:
+                name = _extract_name_tag(item)
+                ret[name] = item
+                ret[name].update(dict(id=item['instanceId'], 
+                                      image=item['imageId'], 
+                                      size=item['instanceType'], 
+                                      state=item['instanceState']['name'], 
+                                      private_ips=item.get('privateIpAddress', []), 
+                                      public_ips=item.get('ipAddress', [])))
+        else:
+            item = instance['instancesSet']['item']
+            name = _extract_name_tag(item)
+            ret[name] = item
+            ret[name].update(dict(id=item['instanceId'], 
+                                  image=item['imageId'], 
+                                  size=item['instanceType'], 
+                                  state=item['instanceState']['name'], 
+                                  private_ips=item.get('privateIpAddress', []), 
+                                  public_ips=item.get('ipAddress', [])))
     return ret
 
 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -992,38 +992,49 @@ def _vm_provider(vm_):
     return vm_.get('provider', __opts__['provider'])
 
 
+def _extract_name_tag(item):
+    if 'tagSet' in item:
+        tagset = item['tagSet']
+        if type(tagset['item']) is list:
+            for tag in tagset['item']:
+                if tag['key'] == 'Name':
+                    return tag['value']
+        else:
+            return (item['tagSet']['item']['value'])
+    else:
+        return item['instanceId']
+
 def _list_nodes_full(location=None):
+    '''
+    Return a list of the VMs that in this location
+    '''
+
     ret = {}
     params = {'Action': 'DescribeInstances'}
     instances = query(params, location=location)
 
     for instance in instances:
-        if 'tagSet' in instance['instancesSet']['item']:
-            tagset = instance['instancesSet']['item']['tagSet']
-            if type(tagset['item']) is list:
-                for tag in tagset['item']:
-                    if tag['key'] == 'Name':
-                        name = tag['value']
-            else:
-                name = (
-                    instance['instancesSet']['item']['tagSet']['item']['value']
-                )
-        else:
-            name = instance['instancesSet']['item']['instanceId']
-        ret[name] = instance['instancesSet']['item']
-        ret[name]['id'] = instance['instancesSet']['item']['instanceId'],
-        ret[name]['image'] = instance['instancesSet']['item']['imageId'],
-        ret[name]['size'] = instance['instancesSet']['item']['instanceType'],
-        ret[name]['state'] = (
-                    instance['instancesSet']['item']['instanceState']['name'])
-        ret[name]['private_ips'] = []
-        ret[name]['public_ips'] = []
-        if 'privateIpAddress' in instance['instancesSet']['item']:
-            ret[name]['private_ips'].append(
-                        instance['instancesSet']['item']['privateIpAddress'])
-        if 'ipAddress' in instance['instancesSet']['item']:
-            ret[name]['public_ips'].append(
-                        instance['instancesSet']['item']['ipAddress'])
+        # items could be type dict or list (for stopped EC2 instances)
+	if isinstance(instance['instancesSet']['item'], list):
+	    for item in instance['instancesSet']['item']:
+		name = _extract_name_tag(item)
+		ret[name] = item
+		ret[name].update(dict(id=item['instanceId'], 
+				 image=item['imageId'], 
+				 size=item['instanceType'], 
+				 state=item['instanceState']['name'], 
+				 private_ips=item.get('privateIpAddress', []), 
+				 public_ips=item.get('ipAddress', [])))
+	else:
+	    item = instance['instancesSet']['item']
+	    name = _extract_name_tag(item)
+	    ret[name] = item
+	    ret[name].update(dict(id=item['instanceId'], 
+			     image=item['imageId'], 
+			     size=item['instanceType'], 
+			     state=item['instanceState']['name'], 
+			     private_ips=item.get('privateIpAddress', []), 
+			     public_ips=item.get('ipAddress', [])))
     return ret
 
 


### PR DESCRIPTION
A query to list EC2 instances might return either a dict or a list (for stopped instances). Need to handle both cases. See the issue cited above for example error messages in the log .
