### PR TITLE
Add support for openstack security groups

### DIFF
--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -188,7 +188,14 @@ def create(vm_):
         kwargs['ex_keyname'] = __opts__['OPENSTACK.ssh_key_name']
 
     if 'security_groups' in vm_:
-        kwargs['ex_security_groups'] = vm_['security_groups'].split(',')
+        groups = vm_['security_groups'].split(',')
+        _groups = conn.ex_list_security_groups()
+        kwargs['ex_security_groups'] = []
+
+        for g in _groups:
+            if g.name in groups:
+                kwargs['ex_security_groups'].append(g)
+
 
     try:
         data = conn.create_node(**kwargs)

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -187,6 +187,9 @@ def create(vm_):
     if 'OPENSTACK.ssh_key_name' in __opts__:
         kwargs['ex_keyname'] = __opts__['OPENSTACK.ssh_key_name']
 
+    if 'security_groups' in vm_:
+        kwargs['ex_security_groups'] = vm_['security_groups'].split(',')
+
     try:
         data = conn.create_node(**kwargs)
     except Exception as exc:

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -188,14 +188,15 @@ def create(vm_):
         kwargs['ex_keyname'] = __opts__['OPENSTACK.ssh_key_name']
 
     if 'security_groups' in vm_:
+        kwargs['ex_security_groups'] = []
         groups = vm_['security_groups'].split(',')
         _groups = conn.ex_list_security_groups()
-        kwargs['ex_security_groups'] = []
 
-        for g in _groups:
-            if g.name in groups:
+        for group in groups:
+            if group in [ g.name for g in _groups ]:
                 kwargs['ex_security_groups'].append(g)
-
+            else:
+                raise ValueError("No such security group: '{0}'".format(group))
 
     try:
         data = conn.create_node(**kwargs)


### PR DESCRIPTION
Add support for a comma-separated list of security groups in the cloud profile when using the openstack provider.

Example profile:

```
webhead:
  provider: openstack
  image: webhead-image
  size: 102
  security_groups: ssh,web
```
