### PR TITLE
Enforce the new providers configuration. Refs #239

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ coverage.xml
 htmlcov/
 /.project
 /.pydevproject
+
+# The bootstrap script
+saltcloud/deploy/bootstrap-salt.sh

--- a/README.rst
+++ b/README.rst
@@ -41,4 +41,4 @@ Join the vibrant, helpful and positive Salt Stack chat room in Freenode at
 just help and be helped! Make sure to wait for an answer, sometimes it may take
 a few moments for someone to reply.
 
-http://webchat.freenode.net/?channels=salt&uio=Mj10cnVlJjk9dHJ1ZSYxMD10cnVl83
+http://webchat.freenode.net/?channels=salt

--- a/doc/topics/aws.rst
+++ b/doc/topics/aws.rst
@@ -99,6 +99,8 @@ Set up the cloud config at ``/etc/salt/cloud``:
       #
       ssh_username: ec2-user
 
+      provider: aws
+
 
     aws-southeast-private-ips:
       # Set up the location of the salt master
@@ -141,6 +143,8 @@ Set up the cloud config at ``/etc/salt/cloud``:
       # Ubuntu       -> ubuntu
       #
       ssh_username: ec2-user
+
+      provider: aws
 
 
 Access Credentials
@@ -229,6 +233,7 @@ The profile can be realized now with a salt command:
     # salt-cloud -p base_aws ami.example.com
     # salt-cloud -p base_aws_public ami.example.com
     # salt-cloud -p base_aws_private ami.example.com
+
 
 This will create an instance named ``ami.example.com`` in EC2. The minion that 
 is installed on this instance will have an ``id`` of ``ami.example.com``. If 
@@ -334,6 +339,7 @@ Bitnami).
 
     # Configure which user to use to run the deploy script
     AWS.ssh_username: ec2-user
+
 
 * Using the new cloud configuration format:
 
@@ -591,6 +597,7 @@ configuration:
 .. code-block:: yaml
 
     EC2.delvol_on_destroy: True
+
 
 * Using the new cloud configuration format:
 

--- a/doc/topics/aws.rst
+++ b/doc/topics/aws.rst
@@ -57,7 +57,7 @@ Set up the cloud config at ``/etc/salt/cloud``:
 
 .. code-block:: yaml
 
-    aws-southeast-public-ips:
+    my-aws-southeast-public-ips:
       # Set up the location of the salt master
       #
       minion:
@@ -102,7 +102,7 @@ Set up the cloud config at ``/etc/salt/cloud``:
       provider: aws
 
 
-    aws-southeast-private-ips:
+    my-aws-southeast-private-ips:
       # Set up the location of the salt master
       #
       minion:
@@ -214,13 +214,13 @@ Set up an initial profile at ``/etc/salt/cloud.profiles``:
 .. code-block:: yaml
 
     base_aws_private:
-      provider: aws-southeast-private-ips
+      provider: my-aws-southeast-private-ips
       image: ami-e565ba8c
       size: Micro Instance
       ssh-user: ec2-user
 
     base_aws_public:
-      provider: aws-southeast-public-ips
+      provider: my-aws-southeast-public-ips
       image: ami-e565ba8c
       size: Micro Instance
       ssh-user: ec2-user
@@ -269,7 +269,7 @@ The following settings are always required for AWS:
 .. code-block:: yaml
 
     # Set the AWS login data
-    aws-config:
+    my-aws-config:
       id: HJGRYCILJLKJYG
       key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
       keyname: test
@@ -297,7 +297,7 @@ zones exist inside regions, and may be added to increase specificity.
 
 .. code-block:: yaml
 
-    aws-config:
+    my-aws-config:
       # Optionally configure default region
       location: ap-southeast-1
       availability_zone: ap-southeast-1b
@@ -321,7 +321,7 @@ run from another AWS instance, the private IP should be used.
 
 .. code-block:: yaml
 
-    aws-config:
+    my-aws-config:
       # Specify whether to use public or private IP for deploy script
       # private_ips or public_ips
       ssh_interface: public_ips
@@ -345,7 +345,7 @@ Bitnami).
 
 .. code-block:: yaml
 
-    aws-config
+    my-aws-config:
       # Configure which user to use to run the deploy script
       ssh_username: ec2-user
 
@@ -369,7 +369,7 @@ file:
 
 .. code-block:: yaml
 
-    aws-config:
+    my-aws-config:
       ssh_username:
         - ec2-user
         - ubuntu
@@ -387,27 +387,40 @@ Multiple security groups can also be specified in the same fashion:
       - default
       - extra
 
-Block device mappings enable you to specify additional EBS volumes or instance
-store volumes when the instance is launched. This setting is also available on
-each cloud profile:
-
-.. code-block:: yaml
-
-    AWS.block_device_mappings:
-        - DeviceName: /dev/sdb
-          VirtualName: ephemeral0
-        - DeviceName: /dev/sdc
-          VirtualName: ephemeral1
-
 
 * Using the old cloud configuration format:
 
 .. code-block:: yaml
 
-    aws-config:
+    my-aws-config:
       securitygroup:
         - default
         - extra
+
+
+Block device mappings enable you to specify additional EBS volumes or instance
+store volumes when the instance is launched. This setting is also available on
+each cloud profile. Using the old cloud configuration format:
+
+.. code-block:: yaml
+
+    AWS.block_device_mappings:
+      - DeviceName: /dev/sdb
+        VirtualName: ephemeral0
+      - DeviceName: /dev/sdc
+        VirtualName: ephemeral1
+
+
+Using the new cloud configuration syntax:
+
+.. code-block:: yaml
+
+    my-aws-config:
+      block_device_mappings:
+        - DeviceName: /dev/sdb
+          VirtualName: ephemeral0
+        - DeviceName: /dev/sdc
+          VirtualName: ephemeral1
 
 
 Modify AWS Tags
@@ -474,7 +487,7 @@ configuration file:
 
 .. code-block:: yaml
 
-    aws-config:
+    my-aws-config:
       rename_on_destroy: True
 
 
@@ -533,13 +546,14 @@ argument names:
 
 .. code-block:: yaml
 
-    ec2-config:
+    my-ec2-config:
       # Set the EC2 login data
       id: HJGRYCILJLKJYG
       key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
       keyname: test
       securitygroup: quick-start
       private_key: /root/test.pem
+      provider: ec2
 
 
 This driver contains optimizations over the old AWS driver, which increase 
@@ -603,7 +617,7 @@ configuration:
 
 .. code-block:: yaml
 
-    ec2-config:
+    my-ec2-config:
       delvol_on_destroy: True
 
 
@@ -655,6 +669,14 @@ directly in the main cloud configuration file:
 .. code-block:: yaml
 
     EC2.endpoint: myendpoint.example.com:1138/services/Cloud
+
+
+Or, when using the new cloud configuration syntax:
+
+.. code-block:: yaml
+
+    my-ec2-config:
+      endpoint: myendpoint.example.com:1138/services/Cloud
 
 
 Volume Management

--- a/doc/topics/aws.rst
+++ b/doc/topics/aws.rst
@@ -7,6 +7,8 @@ platforms Salt Cloud has been built to support.
 
 Set up the cloud config at ``/etc/salt/cloud``:
 
+* Using the old format:
+
 .. code-block:: yaml
 
     # Set up the location of the salt master
@@ -51,23 +53,113 @@ Set up the cloud config at ``/etc/salt/cloud``:
     AWS.ssh_username: ec2-user
 
 
+* Using the new configuration format:
+
+.. code-block:: yaml
+
+    aws-southeast-public-ips:
+      # Set up the location of the salt master
+      #
+      minion:
+        master: saltmaster.example.com
+
+      # Specify whether to use public or private IP for deploy script.
+      #
+      # Valid options are:
+      #     private_ips - The salt-master is also hosted with AWS
+      #     public_ips - The salt-master is hosted outside of AWS
+      #
+      ssh_interface: public_ips
+
+      # Set the AWS access credentials (see below)
+      #
+      id: HJGRYCILJLKJYG
+      key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
+
+      # Make sure this key is owned by root with permissions 0400.
+      #
+      private_key: /etc/salt/my_test_key.pem
+      keyname: my_test_key
+      securitygroup: default
+
+      # Optionally configure default region
+      #
+      location: ap-southeast-1
+      availability_zone: ap-southeast-1b
+
+      # Configure which user to use to run the deploy script. This setting is
+      # dependent upon the AMI that is used to deploy. It is usually safer to
+      # configure this individually in a profile, than globally. Typical users
+      # are:
+      #
+      # Amazon Linux -> ec2-user
+      # RHEL         -> ec2-user
+      # CentOS       -> ec2-user
+      # Ubuntu       -> ubuntu
+      #
+      ssh_username: ec2-user
+
+
+    aws-southeast-private-ips:
+      # Set up the location of the salt master
+      #
+      minion:
+        master: saltmaster.example.com
+
+      # Specify whether to use public or private IP for deploy script.
+      #
+      # Valid options are:
+      #     private_ips - The salt-master is also hosted with AWS
+      #     public_ips - The salt-master is hosted outside of AWS
+      #
+      ssh_interface: private_ips
+
+      # Set the AWS access credentials (see below)
+      #
+      id: HJGRYCILJLKJYG
+      key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
+
+      # Make sure this key is owned by root with permissions 0400.
+      #
+      private_key: /etc/salt/my_test_key.pem
+      keyname: my_test_key
+      securitygroup: default
+
+      # Optionally configure default region
+      #
+      location: ap-southeast-1
+      availability_zone: ap-southeast-1b
+
+      # Configure which user to use to run the deploy script. This setting is
+      # dependent upon the AMI that is used to deploy. It is usually safer to
+      # configure this individually in a profile, than globally. Typical users
+      # are:
+      #
+      # Amazon Linux -> ec2-user
+      # RHEL         -> ec2-user
+      # CentOS       -> ec2-user
+      # Ubuntu       -> ubuntu
+      #
+      ssh_username: ec2-user
+
+
 Access Credentials
 ==================
-The ``id`` and ``key`` settings may be found in the Security Credentials area
+The ``id`` and ``key`` settings may be found in the Security Credentials area 
 of the AWS Account page:
 
 https://portal.aws.amazon.com/gp/aws/securityCredentials
 
-Both are located in the Access Credentials area of the page, under the Access
-Keys tab. The ``id`` setting is labeled Access Key ID, and the ``key`` setting
+Both are located in the Access Credentials area of the page, under the Access 
+Keys tab. The ``id`` setting is labeled Access Key ID, and the ``key`` setting 
 is labeled Secret Access Key.
 
 
 Key Pairs
 =========
-In order to create an instance with Salt installed and configured, a key pair
-will need to be created. This can be done in the EC2 Management Console, in the
-Key Pairs area. These key pairs are unique to a specific region. Keys in the
+In order to create an instance with Salt installed and configured, a key pair 
+will need to be created. This can be done in the EC2 Management Console, in the 
+Key Pairs area. These key pairs are unique to a specific region. Keys in the 
 us-east-1 region can be configured at:
 
 https://console.aws.amazon.com/ec2/home?region=us-east-1#s=KeyPairs
@@ -76,23 +168,24 @@ Keys in the us-west-1 region can be configured at
 
 https://console.aws.amazon.com/ec2/home?region=us-west-1#s=KeyPairs
 
-...and so on. When creating a key pair, the browser will prompt to download a
-pem file. This file must be placed in a directory accessable by Salt Cloud,
+...and so on. When creating a key pair, the browser will prompt to download a 
+pem file. This file must be placed in a directory accessable by Salt Cloud, 
 with permissions set to either 0400 or 0600.
 
 
 Security Groups
 ===============
-An instance on AWS needs to belong to a security group. Like key pairs, these
-are unique to a specific region. These are also configured in the EC2 Management
-Console. Security groups for the us-east-1 region can be configured at:
+An instance on AWS needs to belong to a security group. Like key pairs, these 
+are unique to a specific region. These are also configured in the EC2 
+Management Console. Security groups for the us-east-1 region can be configured 
+at:
 
 https://console.aws.amazon.com/ec2/home?region=us-east-1#s=SecurityGroups
 
 ...and so on.
 
-A security group defines firewall rules which an instance will adhere to. If
-the salt-master is configured outside of AWS, the security group must open the
+A security group defines firewall rules which an instance will adhere to. If 
+the salt-master is configured outside of AWS, the security group must open the 
 SSH port (usually port 22) in order for Salt Cloud to install Salt.
 
 
@@ -100,26 +193,49 @@ Cloud Profiles
 ==============
 Set up an initial profile at ``/etc/salt/cloud.profiles``:
 
+* Using the old cloud providers configuration format:
+
 .. code-block:: yaml
 
     base_aws:
-        provider: aws
-        image: ami-e565ba8c
-        size: Micro Instance
-        ssh-user: ec2-user
+      provider: aws
+      image: ami-e565ba8c
+      size: Micro Instance
+      ssh-user: ec2-user
+
+
+* Using the new cloud providers configuration format and the example 
+  configuration above:
+
+.. code-block:: yaml
+
+    base_aws_private:
+      provider: aws-southeast-private-ips
+      image: ami-e565ba8c
+      size: Micro Instance
+      ssh-user: ec2-user
+
+    base_aws_public:
+      provider: aws-southeast-public-ips
+      image: ami-e565ba8c
+      size: Micro Instance
+      ssh-user: ec2-user
+
 
 The profile can be realized now with a salt command:
 
 .. code-block:: bash
 
     # salt-cloud -p base_aws ami.example.com
+    # salt-cloud -p base_aws_public ami.example.com
+    # salt-cloud -p base_aws_private ami.example.com
 
-This will create an instance named ``ami.example.com`` in EC2. The minion that
-is installed on this instance will have an ``id`` of ``ami.example.com``. If
-the command was executed on the salt-master, its Salt key will automatically be
+This will create an instance named ``ami.example.com`` in EC2. The minion that 
+is installed on this instance will have an ``id`` of ``ami.example.com``. If 
+the command was executed on the salt-master, its Salt key will automatically be 
 signed on the master.
 
-Once the instance has been created with salt-minion installed, connectivity to
+Once the instance has been created with salt-minion installed, connectivity to 
 it can be verified with Salt:
 
 .. code-block:: bash
@@ -131,6 +247,8 @@ Required Settings
 =================
 The following settings are always required for AWS:
 
+* Using the old cloud configuration format:
+
 .. code-block:: yaml
 
     # Set the AWS login data
@@ -141,10 +259,27 @@ The following settings are always required for AWS:
     AWS.private_key: /root/test.pem
 
 
+* Using the new cloud configuration format:
+
+.. code-block:: yaml
+
+    # Set the AWS login data
+    aws-config:
+      id: HJGRYCILJLKJYG
+      key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
+      keyname: test
+      securitygroup: quick-start
+      private_key: /root/test.pem
+      provider: aws
+
+
 Optional Settings
 =================
-AWS allows a location to be set for servers to be deployed in. Availability
+
+AWS allows a location to be set for servers to be deployed in. Availability 
 zones exist inside regions, and may be added to increase specificity.
+
+* Using the old cloud configuration format:
 
 .. code-block:: yaml
 
@@ -152,10 +287,23 @@ zones exist inside regions, and may be added to increase specificity.
     AWS.location: ap-southeast-1
     AWS.availability_zone: ap-southeast-1b
 
-AWS instances can have a public or private IP, or both. When an instance is
+
+* Using the new cloud configuration format:
+
+.. code-block:: yaml
+
+    aws-config:
+      # Optionally configure default region
+      location: ap-southeast-1
+      availability_zone: ap-southeast-1b
+
+
+AWS instances can have a public or private IP, or both. When an instance is 
 deployed, Salt Cloud needs to log into it via SSH to run the deploy script.
-By default, the public IP will be used for this. If the salt-cloud command
-is run from another AWS instance, the private IP should be used.
+By default, the public IP will be used for this. If the salt-cloud command is 
+run from another AWS instance, the private IP should be used.
+
+* Using the old cloud configuration format:
 
 .. code-block:: yaml
 
@@ -163,20 +311,44 @@ is run from another AWS instance, the private IP should be used.
     # private_ips or public_ips
     AWS.ssh_interface: public_ips
 
+
+* Using the new cloud configuration format:
+
+.. code-block:: yaml
+
+    aws-config:
+      # Specify whether to use public or private IP for deploy script
+      # private_ips or public_ips
+      ssh_interface: public_ips
+
+
 Many AWS instances do not allow remote access to the root user by default.
-Instead, another user must be used to run the deploy script using sudo. Some
-common usernames include ec2-user (for Amazon Linux), ubuntu (for Ubuntu
-instances), admin (official Debian) and bitnami (for images provided by
+Instead, another user must be used to run the deploy script using sudo. Some 
+common usernames include ec2-user (for Amazon Linux), ubuntu (for Ubuntu 
+instances), admin (official Debian) and bitnami (for images provided by 
 Bitnami).
+
+* Using the old cloud configuration format:
 
 .. code-block:: yaml
 
     # Configure which user to use to run the deploy script
     AWS.ssh_username: ec2-user
 
-Multiple usernames can be provided, in which case Salt Cloud will attempt to
-guess the correct username. This is mostly useful in the main configuration
+* Using the new cloud configuration format:
+
+.. code-block:: yaml
+
+    aws-config
+      # Configure which user to use to run the deploy script
+      ssh_username: ec2-user
+
+
+Multiple usernames can be provided, in which case Salt Cloud will attempt to 
+guess the correct username. This is mostly useful in the main configuration 
 file:
+
+* Using the old cloud configuration format:
 
 .. code-block:: yaml
 
@@ -186,7 +358,22 @@ file:
       - admin
       - bitnami
 
+
+* Using the new cloud configuration format:
+
+.. code-block:: yaml
+
+    aws-config:
+      ssh_username:
+        - ec2-user
+        - ubuntu
+        - admin
+        - bitnami
+
+
 Multiple security groups can also be specified in the same fashion:
+
+* Using the old cloud configuration format:
 
 .. code-block:: yaml
 
@@ -207,10 +394,20 @@ each cloud profile:
           VirtualName: ephemeral1
 
 
+* Using the old cloud configuration format:
+
+.. code-block:: yaml
+
+    aws-config:
+      securitygroup:
+        - default
+        - extra
+
+
 Modify AWS Tags
 ===============
-One of the features of AWS is the ability to tag resources. In fact, under the
-hood, the names given to EC2 instances by salt-cloud are actually just stored
+One of the features of AWS is the ability to tag resources. In fact, under the 
+hood, the names given to EC2 instances by salt-cloud are actually just stored 
 as a tag called Name. Salt Cloud has the ability to manage these tags:
 
 .. code-block:: bash
@@ -222,8 +419,8 @@ as a tag called Name. Salt Cloud has the ability to manage these tags:
 
 Rename AWS Instances
 ====================
-As mentioned above, AWS instances are named via a tag. However, renaming an
-instance by renaming its tag will cause the salt keys to mismatch. A rename
+As mentioned above, AWS instances are named via a tag. However, renaming an 
+instance by renaming its tag will cause the salt keys to mismatch. A rename 
 function exists which renames both the instance, and the salt keys.
 
 .. code-block:: bash
@@ -233,7 +430,7 @@ function exists which renames both the instance, and the salt keys.
 
 AWS Termination Protection
 ==========================
-AWS allows the user to enable and disable termination protection on a specific
+AWS allows the user to enable and disable termination protection on a specific 
 instance. An instance with this protection enabled cannot be destroyed.
 
 .. code-block:: bash
@@ -244,31 +441,43 @@ instance. An instance with this protection enabled cannot be destroyed.
 
 Rename on Destroy
 =================
-When instances on AWS are destroyed, there will be a lag between the time that
-the action is sent, and the time that Amazon cleans up the instance. During this
-time, the instance still retails a Name tag, which will cause a collision if the
-creation of an instance with the same name is attempted before the cleanup
-occurs. In order to avoid such collisions, Salt Cloud can be configured to
-rename instances when they are destroyed. The new name will look something like:
+When instances on AWS are destroyed, there will be a lag between the time that 
+the action is sent, and the time that Amazon cleans up the instance. During 
+this time, the instance still retails a Name tag, which will cause a collision 
+if the creation of an instance with the same name is attempted before the 
+cleanup occurs. In order to avoid such collisions, Salt Cloud can be configured 
+to rename instances when they are destroyed. The new name will look something 
+like:
 
 .. code-block:: bash
 
     myinstance-DEL20f5b8ad4eb64ed88f2c428df80a1a0c
 
-In order to enable this, add AWS.rename_on_destroy line to the main
+
+In order to enable this, add AWS.rename_on_destroy line to the main 
 configuration file:
+
+* Using the old cloud configuration format:
 
 .. code-block:: yaml
 
     AWS.rename_on_destroy: True
 
 
+* Using the new cloud configuration format:
+
+.. code-block:: yaml
+
+    aws-config:
+      rename_on_destroy: True
+
+
 EC2 Images
 ==========
-The following are lists of available AMI images, generally sorted by OS. These
-lists are on 3rd-party websites, are not managed by Salt Stack in any way. They
-are provided here as a reference for those who are interested, and contain no
-warranty (express or implied) from anyone affiliated with Salt Stack. Most of
+The following are lists of available AMI images, generally sorted by OS. These 
+lists are on 3rd-party websites, are not managed by Salt Stack in any way. They 
+are provided here as a reference for those who are interested, and contain no 
+warranty (express or implied) from anyone affiliated with Salt Stack. Most of 
 them have never been used, much less tested, by the Salt Stack team.
 
 * `Arch Linux`__
@@ -298,9 +507,11 @@ them have never been used, much less tested, by the Salt Stack team.
 
 Experimental EC2 Driver
 =======================
-An experimental driver has been added to Salt Cloud called EC2. The
-configuration for this driver is the same as for AWS, but with EC2 in the
+An experimental driver has been added to Salt Cloud called EC2. The 
+configuration for this driver is the same as for AWS, but with EC2 in the 
 argument names:
+
+* Using the old cloud configuration format:
 
 .. code-block:: yaml
 
@@ -311,21 +522,35 @@ argument names:
     EC2.securitygroup: quick-start
     EC2.private_key: /root/test.pem
 
-This driver contains optimizations over the old AWS driver, which increase
-speed and functionality. However, because this is a new driver, it is currently
-considered to be experimental, and as such, the old AWS driver may still be
+
+* Using the new cloud configuration format:
+
+.. code-block:: yaml
+
+    ec2-config:
+      # Set the EC2 login data
+      id: HJGRYCILJLKJYG
+      key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
+      keyname: test
+      securitygroup: quick-start
+      private_key: /root/test.pem
+
+
+This driver contains optimizations over the old AWS driver, which increase 
+speed and functionality. However, because this is a new driver, it is currently 
+considered to be experimental, and as such, the old AWS driver may still be 
 used as before.
 
-IMPORTANT: Because this driver is in experimental status, its usage and
+IMPORTANT: Because this driver is in experimental status, its usage and 
 configuration should be expected to change.
 
-The remainder of this document describes settings which may be used with the
+The remainder of this document describes settings which may be used with the 
 EC2 driver.
 
 
 show_image
 ==========
-This is a function that describes an AMI on EC2. This will give insight as to
+This is a function that describes an AMI on EC2. This will give insight as to 
 the defaults that will be applied to an instance using a particular AMI.
 
 .. code-block:: bash
@@ -335,9 +560,9 @@ the defaults that will be applied to an instance using a particular AMI.
 
 show_instance
 =============
-This action is a thin wrapper around --full-query, which displays details on a
-single instance only. In an environment with several machines, this will save a
-user from having to sort through all instance data, just to examine a single
+This action is a thin wrapper around --full-query, which displays details on a 
+single instance only. In an environment with several machines, this will save a 
+user from having to sort through all instance data, just to examine a single 
 instance.
 
 .. code-block:: bash
@@ -347,10 +572,10 @@ instance.
 
 delvol_on_destroy
 =================
-This argument overrides the default DeleteOnTermination setting in the AMI for
-the root EBS volume for an instance. Many AMIs contain 'false' as a default,
-resulting in orphaned volumes in the EC2 account, which may unknowingly be
-charged to the account. This setting can be added to the profile or map file
+This argument overrides the default DeleteOnTermination setting in the AMI for 
+the root EBS volume for an instance. Many AMIs contain 'false' as a default, 
+resulting in orphaned volumes in the EC2 account, which may unknowingly be 
+charged to the account. This setting can be added to the profile or map file 
 for an instance.
 
 .. code-block:: yaml
@@ -358,14 +583,25 @@ for an instance.
     delvol_on_destroy: True
 
 
-This can also be set as a global setting in the EC2 cloud configuration:
+This can also be set as a cloud provider setting in the EC2 cloud 
+configuration:
+
+* Using the old cloud configuration format:
 
 .. code-block:: yaml
 
     EC2.delvol_on_destroy: True
 
+* Using the new cloud configuration format:
 
-The setting for this may be changed on an existing instance using one of the
+.. code-block:: yaml
+
+    ec2-config:
+      delvol_on_destroy: True
+
+
+
+The setting for this may be changed on an existing instance using one of the 
 following commands:
 
 .. code-block:: bash
@@ -376,8 +612,9 @@ following commands:
 
 EC2 Termination Protection
 ==========================
-AWS allows the user to enable and disable termination protection on a specific
-instance. An instance with this protection enabled cannot be destroyed. The EC2
+
+AWS allows the user to enable and disable termination protection on a specific 
+instance. An instance with this protection enabled cannot be destroyed. The EC2 
 driver adds a show_term_protect action to the regular AWS functionality.
 
 .. code-block:: bash
@@ -389,12 +626,13 @@ driver adds a show_term_protect action to the regular AWS functionality.
 
 Alternate Endpoint
 ==================
-Normally, ec2 endpoints are build using the region and the service_url. The
+Normally, EC2 endpoints are build using the region and the service_url. The 
 resulting endpoint would follow this pattern:
 
 .. code-block::
 
     ec2.<region>.<service_url>
+
 
 This results in an endpoint that looks like:
 
@@ -402,8 +640,9 @@ This results in an endpoint that looks like:
 
     ec2.us-east-1.amazonaws.com
 
-There are other projects that support an EC2 compatibility layer, which this
-scheme does not account for. This can be overridden by specifying the endpoint
+
+There are other projects that support an EC2 compatibility layer, which this 
+scheme does not account for. This can be overridden by specifying the endpoint 
 directly in the main cloud configuration file:
 
 .. code-block:: yaml
@@ -419,8 +658,8 @@ The EC2 driver has several functions and actions for management of EBS volumes.
 Creating Volumes
 ----------------
 A volume may be created, independent of an instance. A zone must be specified.
-A size or a snapshot may be specified (in GiB). If neither is given, a default
-size of 10 GiB will be used. If a snapshot is given, the size of the snapshot
+A size or a snapshot may be specified (in GiB). If neither is given, a default 
+size of 10 GiB will be used. If a snapshot is given, the size of the snapshot 
 will be used.
 
 .. code-block:: bash
@@ -432,8 +671,8 @@ will be used.
 
 Attaching Volumes
 -----------------
-Unattached volumes may be attached to an instance. The following values are
-required: name or instance_id, volume_id and device.
+Unattached volumes may be attached to an instance. The following values are 
+required; name or instance_id, volume_id and device.
 
 .. code-block:: bash
 
@@ -442,7 +681,7 @@ required: name or instance_id, volume_id and device.
 
 Show a Volume
 -------------
-The details about an existing volume may be retreived.
+The details about an existing volume may be retrieved.
 
 .. code-block:: bash
 
@@ -475,9 +714,9 @@ The EC2 driver has the ability to manage key pairs.
 
 Creating a Key Pair
 -------------------
-A key pair is required in order to create an instance. When creating a key pair
+A key pair is required in order to create an instance. When creating a key pair 
 with this function, the return data will contain a copy of the private key.
-This private key is not stored by Amazon, and will not be obtainable past this
+This private key is not stored by Amazon, and will not be obtainable past this 
 point, and should be stored immediately.
 
 .. code-block:: bash
@@ -487,7 +726,7 @@ point, and should be stored immediately.
 
 Show a Key Pair
 ---------------
-This function will show the details related to a key pair, not including the
+This function will show the details related to a key pair, not including the 
 private key itself (which is not stored by Amazon).
 
 .. code-block:: bash

--- a/doc/topics/config.rst
+++ b/doc/topics/config.rst
@@ -355,3 +355,80 @@ already set) in order to find the name of the location that you want to use.
 **NOTE**: With the new providers configuration syntax you would have 
 ``provider: imbsce-config`` instead of ``provider: ibmsce`` on a profile 
 configuration.
+
+
+Extending Profiles and Cloud Providers Configuration
+====================================================
+
+As of 0.8.7, the option to extend both the profiles and cloud providers 
+configuration and avoid duplication was added. The extends feature works on the 
+current profiles configuration, but, regarding the cloud providers 
+configuration, **only** works in the new syntax and respective configuration 
+files, ie, ``/etc/salt/salt/cloud.providers`` or 
+``/etc/salt/cloud.providers.d/*.conf``.
+
+
+Extending Profiles
+------------------
+
+Some example usage on how to use ``extends`` with profiles. Consider 
+``/etc/salt/salt/cloud.profiles`` containing:
+
+.. code-block:: yaml
+
+    development-instances:
+      provider: ec2-config
+      size: Micro Instance
+      ssh_username: ec2_user
+      securitygroup:
+        - default
+      deploy: False
+
+    Amazon-Linux-AMI-2012.09-64bit:
+      image: ami-54cf5c3d
+      extends: development-instances
+
+    Fedora-17:
+      image: ami-08d97e61
+      extends: development-instances
+
+    CentOS-5:
+      provider: aws-config
+      image: ami-09b61d60
+      extends: development-instances
+
+
+The above configuration, once parsed would generate the following profiles 
+data:
+
+.. code-block:: text
+
+    [{'deploy': False,
+      'image': 'ami-08d97e61',
+      'profile': 'Fedora-17',
+      'provider': 'ec2-config',
+      'securitygroup': ['default'],
+      'size': 'Micro Instance',
+      'ssh_username': 'ec2_user'},
+     {'deploy': False,
+      'image': 'ami-09b61d60',
+      'profile': 'CentOS-5',
+      'provider': 'aws-config',
+      'securitygroup': ['default'],
+      'size': 'Micro Instance',
+      'ssh_username': 'ec2_user'},
+     {'deploy': False,
+      'image': 'ami-54cf5c3d',
+      'profile': 'Amazon-Linux-AMI-2012.09-64bit',
+      'provider': 'ec2-config',
+      'securitygroup': ['default'],
+      'size': 'Micro Instance',
+      'ssh_username': 'ec2_user'},
+     {'deploy': False,
+      'profile': 'development-instances',
+      'provider': 'ec2-config',
+      'securitygroup': ['default'],
+      'size': 'Micro Instance',
+      'ssh_username': 'ec2_user'}]
+
+Pretty cool right?

--- a/doc/topics/config.rst
+++ b/doc/topics/config.rst
@@ -61,7 +61,7 @@ Rackspace cloud requires two configuration options:
 
 .. code-block:: yaml
 
-    rackspace-config:
+    my-rackspace-config:
       user: example_user
       apikey: 123984bjjas87034
       provider: rackspace
@@ -92,7 +92,7 @@ A number of configuration options are required for Amazon AWS:
 
 .. code-block:: yaml
 
-    aws-quick-start:
+    my-aws-quick-start:
       id: HJGRYCILJLKJYG
       key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
       keyname: test
@@ -100,7 +100,7 @@ A number of configuration options are required for Amazon AWS:
       private_key: /root/test.pem
       provider: aws
 
-    aws-default:
+    my-aws-default:
       id: HJGRYCILJLKJYG
       key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
       keyname: test
@@ -110,8 +110,9 @@ A number of configuration options are required for Amazon AWS:
 
 
 **NOTE**: With the new providers configuration syntax you would have 
-``provider: aws-quick-start`` or ``provider: aws-default`` instead of 
+``provider: my-aws-quick-start`` or ``provider: my-aws-default`` instead of 
 ``provider: aws`` on a profile configuration.
+
 
 Linode
 ------
@@ -131,14 +132,15 @@ be set:
 
 .. code-block:: yaml
 
-    linode-foo:
+    my-linode-config:
       apikey: asldkgfakl;sdfjsjaslfjaklsdjf;askldjfaaklsjdfhasldsadfghdkf
       password: F00barbaz
       provider: linode
 
 
-**NOTE**: With the new providers configuration syntax you would have ``provider: 
-linode-foo`` instead of ``provider: linode`` on a profile configuration.
+**NOTE**: With the new providers configuration syntax you would have 
+``provider: my-linode-config`` instead of ``provider: linode`` on a profile 
+configuration.
 
 The password needs to be 8 characters and contain lowercase, uppercase and 
 numbers.
@@ -165,15 +167,16 @@ send the provisioning commands up to the freshly created virtual machine,
 
 .. code-block:: yaml
 
-    joyent-config:
+    my-joyent-config:
         user: fred
         password: saltybacon
         private_key: /root/joyent.pem
         provider: joyent
 
 
-**NOTE**: With the new providers configuration syntax you would have ``provider: 
-joyent-config`` instead of ``provider: joyent`` on a profile configuration.
+**NOTE**: With the new providers configuration syntax you would have 
+``provider: my-joyent-config`` instead of ``provider: joyent`` on a profile 
+configuration.
 
 
 GoGrid
@@ -198,14 +201,14 @@ be set in the configuration file to enable interfacing with GoGrid:
 
 .. code-block:: yaml
 
-    gogrid-config:
+    my-gogrid-config:
       apikey: asdff7896asdh789
       sharedsecret: saltybacon
       provider: gogrid
 
 
 **NOTE**: With the new providers configuration syntax you would have 
-``provider: gogrid-config`` instead of ``provider: gogrid`` on a profile 
+``provider: my-gogrid-config`` instead of ``provider: gogrid`` on a profile 
 configuration.
 
 
@@ -255,7 +258,7 @@ password:
 .. code-block:: yaml
 
     # For HP
-    openstack-hp-config:
+    my-openstack-hp-config:
       identity_url: 
       'https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/'
       compute_name: Compute
@@ -268,7 +271,7 @@ password:
       provider: openstack
 
     # For Rackspace
-    openstack-rackspace-config:
+    my-openstack-rackspace-config:
       identity_url: 'https://identity.api.rackspacecloud.com/v2.0/tokens'
       compute_name: cloudServersOpenStack
       protocol: ipv4
@@ -285,16 +288,17 @@ password:
 
 .. code-block:: yaml
 
-    openstack-hp-config:
+    my-openstack-hp-config:
       apikey: 901d3f579h23c8v73q9
 
-    openstack-rackspace-config:
+    my-openstack-rackspace-config:
       apikey: 901d3f579h23c8v73q9
 
 
 **NOTE**: With the new providers configuration syntax you would have 
-``provider: openstack-hp-config`` or ``provider: openstack-rackspace-config`` 
-instead of ``provider: openstack`` on a profile configuration.
+``provider: my-openstack-hp-config`` or ``provider: 
+my-openstack-rackspace-config`` instead of ``provider: openstack`` on a profile 
+configuration.
 
 
 You will certainly need to configure the ``user``, ``tenant`` and either 
@@ -314,7 +318,7 @@ Using the new syntax:
 
 .. code-block:: yaml
 
-    openstack-config:
+    my-openstack-config:
       ignore_cidr: 192.168.0.0/16
 
 
@@ -343,7 +347,7 @@ already set) in order to find the name of the location that you want to use.
 
 .. code-block:: yaml
 
-    ibmsce-config:
+    my-ibmsce-config:
       user: myuser@mycorp.com
       password: mypass
       ssh_key_name: mykey
@@ -353,7 +357,7 @@ already set) in order to find the name of the location that you want to use.
 
 
 **NOTE**: With the new providers configuration syntax you would have 
-``provider: imbsce-config`` instead of ``provider: ibmsce`` on a profile 
+``provider: my-imbsce-config`` instead of ``provider: ibmsce`` on a profile 
 configuration.
 
 
@@ -377,7 +381,7 @@ Some example usage on how to use ``extends`` with profiles. Consider
 .. code-block:: yaml
 
     development-instances:
-      provider: ec2-config
+      provider: my-ec2-config
       size: Micro Instance
       ssh_username: ec2_user
       securitygroup:
@@ -393,7 +397,7 @@ Some example usage on how to use ``extends`` with profiles. Consider
       extends: development-instances
 
     CentOS-5:
-      provider: aws-config
+      provider: my-aws-config
       image: ami-09b61d60
       extends: development-instances
 
@@ -406,27 +410,27 @@ data:
     [{'deploy': False,
       'image': 'ami-08d97e61',
       'profile': 'Fedora-17',
-      'provider': 'ec2-config',
+      'provider': 'my-ec2-config',
       'securitygroup': ['default'],
       'size': 'Micro Instance',
       'ssh_username': 'ec2_user'},
      {'deploy': False,
       'image': 'ami-09b61d60',
       'profile': 'CentOS-5',
-      'provider': 'aws-config',
+      'provider': 'my-aws-config',
       'securitygroup': ['default'],
       'size': 'Micro Instance',
       'ssh_username': 'ec2_user'},
      {'deploy': False,
       'image': 'ami-54cf5c3d',
       'profile': 'Amazon-Linux-AMI-2012.09-64bit',
-      'provider': 'ec2-config',
+      'provider': 'my-ec2-config',
       'securitygroup': ['default'],
       'size': 'Micro Instance',
       'ssh_username': 'ec2_user'},
      {'deploy': False,
       'profile': 'development-instances',
-      'provider': 'ec2-config',
+      'provider': 'my-ec2-config',
       'securitygroup': ['default'],
       'size': 'Micro Instance',
       'ssh_username': 'ec2_user'}]
@@ -443,7 +447,7 @@ configuration.  Consider ``/etc/salt/salt/cloud.providers`` containing:
 
 .. code-block:: yaml
 
-    develop-envs:
+    my-develop-envs:
       - id: HJGRYCILJLKJYG
       key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
       keyname: test
@@ -461,7 +465,7 @@ configuration.  Consider ``/etc/salt/salt/cloud.providers`` containing:
       provider: ibmsce
 
 
-    productions-envs:
+    my-productions-envs:
       - extends: develop-envs:ibmsce
         user: my-production-user@mycorp.com
         location: us-east-1

--- a/doc/topics/config.rst
+++ b/doc/topics/config.rst
@@ -2,21 +2,22 @@
 Core Configuration
 ==================
 
-A number of core configuration options and some options that are global to the
-VM profiles can be set in the cloud config file. By default this file is
+A number of core configuration options and some options that are global to the 
+VM profiles can be set in the cloud configuration file. By default this file is 
 located at ``/etc/salt/cloud``.
 
 
 Minion Configuration
 ====================
 
-The default minion configuration is set up in this file. This is where the
+The default minion configuration is set up in this file. This is where the 
 minions that are created derive their configuration.
 
 .. code-block:: yaml
 
     minion:
         master: saltmaster.example.com
+
 
 This is the location in particular to specify the location of the salt master.
 
@@ -26,20 +27,57 @@ Cloud Configurations
 
 The data specific to interacting with public clouds is set up here.
 
+**ATTENTION**: Since version 0.8.7 a new cloud provider configuration syntax 
+was implemented.  It will allow for multiple configurations of the same cloud 
+provider where only minor details can change, for example, the region for an 
+EC2 instance. While the old format is still supported and automatically 
+migrated every time salt-cloud configuration is parsed, a choice was made to 
+warn the user or even exit with an error if both formats are mixed.
+
+While moving towards an improved and extensible configuration handling 
+regarding the cloud providers, ``--providers-config``, which defaults to 
+``/etc/salt/cloud.providers`` was added to the cli parser.  It allows for the 
+cloud providers configuration to be provided in a different file, and/or even 
+any matching file on a sub-directory, ``cloud.providers.d/*.conf`` which is 
+relative to the providers configuration file(with the above configuration file 
+as an example, ``/etc/salt/cloud.providers.d/*.conf``).
+
+
 Rackspace
 ---------
 
 Rackspace cloud requires two configuration options:
+
+* Using the old format:
 
 .. code-block:: yaml
 
     RACKSPACE.user: example_user
     RACKSPACE.apikey: 123984bjjas87034
 
+
+
+* Using the new configuration format:
+
+.. code-block:: yaml
+
+    rackspace-config:
+      user: example_user
+      apikey: 123984bjjas87034
+      provider: rackspace
+
+
+**NOTE**: With the new providers configuration syntax you would have ``provider: 
+rackspace-config`` instead of ``provider: rackspace`` on a profile 
+configuration.
+
+
 Amazon AWS
 ----------
 
 A number of configuration options are required for Amazon AWS:
+
+* Using the old format:
 
 .. code-block:: yaml
 
@@ -49,27 +87,72 @@ A number of configuration options are required for Amazon AWS:
     AWS.securitygroup: quick-start
     AWS.private_key: /root/test.pem
 
+
+* Using the new configuration format:
+
+.. code-block:: yaml
+
+    aws-quick-start:
+      id: HJGRYCILJLKJYG
+      key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
+      keyname: test
+      securitygroup: quick-start
+      private_key: /root/test.pem
+      provider: aws
+
+    aws-default:
+      id: HJGRYCILJLKJYG
+      key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
+      keyname: test
+      securitygroup: default
+      private_key: /root/test.pem
+      provider: aws
+
+
+**NOTE**: With the new providers configuration syntax you would have 
+``provider: aws-quick-start`` or ``provider: aws-default`` instead of 
+``provider: aws`` on a profile configuration.
+
 Linode
 ------
 
-Linode requires a single api key, but the default root password also needs
-to be set:
+Linode requires a single API key, but the default root password also needs to 
+be set:
+
+* Using the old format:
 
 .. code-block:: yaml
 
     LINODE.apikey: asldkgfakl;sdfjsjaslfjaklsdjf;askldjfaaklsjdfhasldsadfghdkf
     LINODE.password: F00barbaz
 
-The password needs to be 8 characters and contain lowercase, uppercase and
+
+* Using the new configuration format:
+
+.. code-block:: yaml
+
+    linode-foo:
+      apikey: asldkgfakl;sdfjsjaslfjaklsdjf;askldjfaaklsjdfhasldsadfghdkf
+      password: F00barbaz
+      provider: linode
+
+
+**NOTE**: With the new providers configuration syntax you would have ``provider: 
+linode-foo`` instead of ``provider: linode`` on a profile configuration.
+
+The password needs to be 8 characters and contain lowercase, uppercase and 
 numbers.
+
 
 Joyent Cloud
 ------------
 
-The Joyent cloud requires three configuration paramaters. The user name and
-password that are used to log into the Joyent system, and the location of
-the private ssh key associated with the Joyent account. The ssh key is needed
-to send the provisioning commands up to the freshly created virtual machine,
+The Joyent cloud requires three configuration parameters. The user name and 
+password that are used to log into the Joyent system, and the location of the 
+private ssh key associated with the Joyent account. The ssh key is needed to 
+send the provisioning commands up to the freshly created virtual machine,
+
+* Using the old format:
 
 .. code-block:: yaml
 
@@ -77,28 +160,64 @@ to send the provisioning commands up to the freshly created virtual machine,
     JOYENT.password: saltybacon
     JOYENT.private_key: /root/joyent.pem
 
+
+* Using the new configuration format:
+
+.. code-block:: yaml
+
+    joyent-config:
+        user: fred
+        password: saltybacon
+        private_key: /root/joyent.pem
+        provider: joyent
+
+
+**NOTE**: With the new providers configuration syntax you would have ``provider: 
+joyent-config`` instead of ``provider: joyent`` on a profile configuration.
+
+
 GoGrid
 ------
 
-To use Salt Cloud with GoGrid log into the GoGrid web interface and
-create an api key. Do this by clicking on "My Account" and then going to the
-API Keys tab.
+To use Salt Cloud with GoGrid log into the GoGrid web interface and create an 
+API key. Do this by clicking on "My Account" and then going to the API Keys 
+tab.
 
-The GOGRID.apikey and the GOGRID.sharedsecret configuration paramaters need to
-be set in the config file to enable interfacing with GoGrid:
+The GOGRID.apikey and the GOGRID.sharedsecret configuration parameters need to
+be set in the configuration file to enable interfacing with GoGrid:
+
+* Using the old format:
 
 .. code-block:: yaml
 
     GOGRID.apikey: asdff7896asdh789
     GOGRID.sharedsecret: saltybacon
 
+
+* Using the new configuration format:
+
+.. code-block:: yaml
+
+    gogrid-config:
+      apikey: asdff7896asdh789
+      sharedsecret: saltybacon
+      provider: gogrid
+
+
+**NOTE**: With the new providers configuration syntax you would have 
+``provider: gogrid-config`` instead of ``provider: gogrid`` on a profile 
+configuration.
+
+
 OpenStack
 ---------
 
-OpenStack configuration differs between providers, and at the moment several
-options need to be specified. This module has been officially tested against
-the HP and the Rackspace implementations, and some examples are provided for
+OpenStack configuration differs between providers, and at the moment several 
+options need to be specified. This module has been officially tested against 
+the HP and the Rackspace implementations, and some examples are provided for 
 both.
+
+* Using the old format:
 
 .. code-block:: yaml
 
@@ -122,32 +241,93 @@ both.
   OPENSTACK.tenant: 5555555
   OPENSTACK.password: mypass
 
-If you have an API key for your provider, it may be specified instead of a
+
+If you have an API key for your provider, it may be specified instead of a 
 password:
 
 .. code-block:: yaml
 
   OPENSTACK.apikey: 901d3f579h23c8v73q9
 
-You will certainly need to configure the ``user``, ``tenant`` and either
-``password`` or ``apikey``.
 
-If your OpenStack instances only have private IP addresses and a CIDR range of
-private addresses are not reachable from the salt-master, you may set your
-preference to have Salt ignore it:
+* Using the new configuration format:
 
 .. code-block:: yaml
 
-  OPENSTACK.ignore_cidr: 192.168.0.0/16
+    # For HP
+    openstack-hp-config:
+      identity_url: 
+      'https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/'
+      compute_name: Compute
+      compute_region: 'az-1.region-a.geo-1'
+      tenant: myuser-tenant1
+      user: myuser
+      ssh_key_name: mykey
+      ssh_key_file: '/etc/salt/hpcloud/mykey.pem'
+      password: mypass
+      provider: openstack
+
+    # For Rackspace
+    openstack-rackspace-config:
+      identity_url: 'https://identity.api.rackspacecloud.com/v2.0/tokens'
+      compute_name: cloudServersOpenStack
+      protocol: ipv4
+      compute_region: DFW
+      protocol: ipv4
+      user: myuser
+      tenant: 5555555
+      password: mypass
+      provider: openstack
+
+
+If you have an API key for your provider, it may be specified instead of a 
+password:
+
+.. code-block:: yaml
+
+    openstack-hp-config:
+      apikey: 901d3f579h23c8v73q9
+
+    openstack-rackspace-config:
+      apikey: 901d3f579h23c8v73q9
+
+
+**NOTE**: With the new providers configuration syntax you would have 
+``provider: openstack-hp-config`` or ``provider: openstack-rackspace-config`` 
+instead of ``provider: openstack`` on a profile configuration.
+
+
+You will certainly need to configure the ``user``, ``tenant`` and either 
+``password`` or ``apikey``.
+
+
+If your OpenStack instances only have private IP addresses and a CIDR range of
+private addresses are not reachable from the salt-master, you may set your
+preference to have Salt ignore it. Using the old could configurations syntax:
+
+.. code-block:: yaml
+
+    OPENSTACK.ignore_cidr: 192.168.0.0/16
+
+
+Using the new syntax:
+
+.. code-block:: yaml
+
+    openstack-config:
+      ignore_cidr: 192.168.0.0/16
+
 
 IBM SmartCloud Enterprise
 -------------------------
 
-In addition to a username and password, the IBM SCE module requires an SSH key,
-which is currently configured inside IBM's web interface. A location is also
-required to create instances, but not to query their cloud. This is important,
-because you need to use salt-cloud --list-locations (with the other options
+In addition to a username and password, the IBM SCE module requires an SSH key, 
+which is currently configured inside IBM's web interface. A location is also 
+required to create instances, but not to query their cloud. This is important, 
+because you need to use salt-cloud --list-locations (with the other options 
 already set) in order to find the name of the location that you want to use.
+
+* Using the old format:
 
 .. code-block:: yaml
 
@@ -158,3 +338,20 @@ already set) in order to find the name of the location that you want to use.
   IBMSCE.location: Raleigh
 
 
+
+* Using the new configuration format:
+
+.. code-block:: yaml
+
+    ibmsce-config:
+      user: myuser@mycorp.com
+      password: mypass
+      ssh_key_name: mykey
+      ssh_key_file: '/etc/salt/ibm/mykey.pem'
+      location: Raleigh
+      provider: ibmsce
+
+
+**NOTE**: With the new providers configuration syntax you would have 
+``provider: imbsce-config`` instead of ``provider: ibmsce`` on a profile 
+configuration.

--- a/doc/topics/config.rst
+++ b/doc/topics/config.rst
@@ -405,7 +405,7 @@ Some example usage on how to use ``extends`` with profiles. Consider
 The above configuration, once parsed would generate the following profiles 
 data:
 
-.. code-block:: text
+.. code-block:: python
 
     [{'deploy': False,
       'image': 'ami-08d97e61',
@@ -466,8 +466,45 @@ configuration.  Consider ``/etc/salt/salt/cloud.providers`` containing:
 
 
     my-productions-envs:
-      - extends: develop-envs:ibmsce
+      - extends: my-develop-envs:ibmsce
         user: my-production-user@mycorp.com
         location: us-east-1
         availability_zone: us-east-1
+
+
+The above configuration, once parsed would generate the following providers 
+data:
+
+.. code-block:: python
+
+    'providers': {
+        'my-develop-envs': [
+            {'availability_zone': 'ap-southeast-1b',
+             'id': 'HJGRYCILJLKJYG',
+             'key': 'kdjgfsgm;woormgl/aserigjksjdhasdfgn',
+             'keyname': 'test',
+             'location': 'ap-southeast-1',
+             'private_key': '/root/test.pem',
+             'provider': 'aws',
+             'securitygroup': 'quick-start'
+            },
+            {'location': 'Raleigh',
+             'password': 'mypass',
+             'provider': 'ibmsce',
+             'ssh_key_file': '/etc/salt/ibm/mykey.pem',
+             'ssh_key_name': 'mykey',
+             'user': 'myuser@mycorp.com'
+            }
+        ],
+        'my-productions-envs': [
+            {'availability_zone': 'us-east-1',
+             'location': 'us-east-1',
+             'password': 'mypass',
+             'provider': 'ibmsce',
+             'ssh_key_file': '/etc/salt/ibm/mykey.pem',
+             'ssh_key_name': 'mykey',
+             'user': 'my-production-user@mycorp.com'
+            }
+        ]
+    }
 

--- a/doc/topics/config.rst
+++ b/doc/topics/config.rst
@@ -432,3 +432,38 @@ data:
       'ssh_username': 'ec2_user'}]
 
 Pretty cool right?
+
+
+Extending Providers
+-------------------
+
+Some example usage on how to use ``extends`` within the cloud providers 
+configuration.  Consider ``/etc/salt/salt/cloud.providers`` containing:
+
+
+.. code-block:: yaml
+
+    develop-envs:
+      - id: HJGRYCILJLKJYG
+      key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
+      keyname: test
+      securitygroup: quick-start
+      private_key: /root/test.pem
+      location: ap-southeast-1
+      availability_zone: ap-southeast-1b
+      provider: aws
+
+      - user: myuser@mycorp.com
+      password: mypass
+      ssh_key_name: mykey
+      ssh_key_file: '/etc/salt/ibm/mykey.pem'
+      location: Raleigh
+      provider: ibmsce
+
+
+    productions-envs:
+      - extends: develop-envs:ibmsce
+        user: my-production-user@mycorp.com
+        location: us-east-1
+        availability_zone: us-east-1
+

--- a/doc/topics/config.rst
+++ b/doc/topics/config.rst
@@ -449,20 +449,20 @@ configuration.  Consider ``/etc/salt/salt/cloud.providers`` containing:
 
     my-develop-envs:
       - id: HJGRYCILJLKJYG
-      key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
-      keyname: test
-      securitygroup: quick-start
-      private_key: /root/test.pem
-      location: ap-southeast-1
-      availability_zone: ap-southeast-1b
-      provider: aws
+        key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
+        keyname: test
+        securitygroup: quick-start
+        private_key: /root/test.pem
+        location: ap-southeast-1
+        availability_zone: ap-southeast-1b
+        provider: aws
 
       - user: myuser@mycorp.com
-      password: mypass
-      ssh_key_name: mykey
-      ssh_key_file: '/etc/salt/ibm/mykey.pem'
-      location: Raleigh
-      provider: ibmsce
+        password: mypass
+        ssh_key_name: mykey
+        ssh_key_file: '/etc/salt/ibm/mykey.pem'
+        location: Raleigh
+        provider: ibmsce
 
 
     my-productions-envs:

--- a/doc/topics/parallels.rst
+++ b/doc/topics/parallels.rst
@@ -33,7 +33,7 @@ http://www.parallels.com/products/pcs/
 
 .. code-block:: yaml
 
-    parallels-config:
+    my-parallels-config:
       # Set up the location of the salt master
       #
       minion:
@@ -78,7 +78,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
 .. code-block:: yaml
 
     parallels-ubuntu:
-        provider: parallels-config
+        provider: my-parallels-config
         image: ubuntu-12.04-x86_64
 
 
@@ -120,7 +120,7 @@ The following settings are always required for PARALLELS:
 
 .. code-block:: yaml
 
-    parallels-config:
+    my-parallels-config:
       user: myuser
       password: badpass
       url: https://api.cloud.xmission.com:4465/paci/v1.0/

--- a/doc/topics/parallels.rst
+++ b/doc/topics/parallels.rst
@@ -2,13 +2,13 @@
 Getting Started With Parallels
 ==============================
 
-Parallels Cloud Server is a product by Parallels that delivers a cloud hosting
-solution. The PARALLELS module for Salt Cloud enables you to manage instances
+Parallels Cloud Server is a product by Parallels that delivers a cloud hosting 
+solution. The PARALLELS module for Salt Cloud enables you to manage instances 
 hosted by a provider using PCS. Further information can be found at:
 
 http://www.parallels.com/products/pcs/
 
-Set up the cloud config at ``/etc/salt/cloud``:
+* Using the old format, set up the cloud configuration at ``/etc/salt/cloud``:
 
 .. code-block:: yaml
 
@@ -27,15 +27,42 @@ Set up the cloud config at ``/etc/salt/cloud``:
     PARALLELS.url: https://api.cloud.xmission.com:4465/paci/v1.0/
 
 
+* Using the new format, set up the cloud configuration at 
+  ``/etc/salt/cloud.providers`` or 
+  ``/etc/salt/cloud.providers.d/parallels.conf``:
+
+.. code-block:: yaml
+
+    parallels-config:
+      # Set up the location of the salt master
+      #
+      minion:
+        master: saltmaster.example.com
+
+      # Set the PARALLELS access credentials (see below)
+      #
+      user: myuser
+      password: badpass
+
+      # Set the access URL for your PARALLELS provider
+      #
+      url: https://api.cloud.xmission.com:4465/paci/v1.0/
+
+
+
 Access Credentials
 ==================
-The ``user``, ``password`` and ``url`` will be provided to you by your cloud
+The ``user``, ``password`` and ``url`` will be provided to you by your cloud 
 provider. These are all required in order for the PARALLELS driver to work.
 
 
 Cloud Profiles
 ==============
-Set up an initial profile at ``/etc/salt/cloud.profiles``:
+Set up an initial profile at ``/etc/salt/cloud.profiles`` or 
+``/etc/salt/cloud.profiles.d/parallels.conf``:
+
+
+* Using the old cloud configuration format:
 
 .. code-block:: yaml
 
@@ -43,18 +70,30 @@ Set up an initial profile at ``/etc/salt/cloud.profiles``:
         provider: parallels
         image: ubuntu-12.04-x86_64
 
+
+* Using the new cloud configuration format and the cloud configuration example 
+  from above:
+
+.. code-block:: yaml
+
+    parallels-ubuntu:
+        provider: parallels-config
+        image: ubuntu-12.04-x86_64
+
+
+
 The profile can be realized now with a salt command:
 
 .. code-block:: bash
 
     # salt-cloud -p parallels-ubuntu myubuntu
 
-This will create an instance named ``myubuntu`` on the cloud provider. The
+This will create an instance named ``myubuntu`` on the cloud provider. The 
 minion that is installed on this instance will have an ``id`` of ``myubuntu``.
-If the command was executed on the salt-master, its Salt key will automatically
+If the command was executed on the salt-master, its Salt key will automatically 
 be signed on the master.
 
-Once the instance has been created with salt-minion installed, connectivity to
+Once the instance has been created with salt-minion installed, connectivity to 
 it can be verified with Salt:
 
 .. code-block:: bash
@@ -66,6 +105,9 @@ Required Settings
 =================
 The following settings are always required for PARALLELS:
 
+
+* Using the old cloud configuration format:
+
 .. code-block:: yaml
 
     PARALLELS.user: myuser
@@ -73,12 +115,23 @@ The following settings are always required for PARALLELS:
     PARALLELS.url: https://api.cloud.xmission.com:4465/paci/v1.0/
 
 
+* Using the new cloud configuration format:
+
+.. code-block:: yaml
+
+    parallels-config:
+      user: myuser
+      password: badpass
+      url: https://api.cloud.xmission.com:4465/paci/v1.0/
+
+
+
 Optional Settings
 =================
-Unlike other cloud providers in Salt Cloud, Parallels does not utilize a
-``size`` setting. This is because Parallels allows the end-user to specify a
-more detailed configuration for their instances, than is allowed by many other
-cloud providers. The following options are available to be used in a profile,
+Unlike other cloud providers in Salt Cloud, Parallels does not utilize a 
+``size`` setting. This is because Parallels allows the end-user to specify a 
+more detailed configuration for their instances, than is allowed by many other 
+cloud providers. The following options are available to be used in a profile, 
 with their default settings listed.
 
 .. code-block:: yaml

--- a/doc/topics/parallels.rst
+++ b/doc/topics/parallels.rst
@@ -47,6 +47,7 @@ http://www.parallels.com/products/pcs/
       # Set the access URL for your PARALLELS provider
       #
       url: https://api.cloud.xmission.com:4465/paci/v1.0/
+      provider: parallels
 
 
 
@@ -123,7 +124,7 @@ The following settings are always required for PARALLELS:
       user: myuser
       password: badpass
       url: https://api.cloud.xmission.com:4465/paci/v1.0/
-
+      provider: parallels
 
 
 Optional Settings
@@ -161,4 +162,3 @@ with their default settings listed.
 
     # The name of the image, from ``salt-cloud --list-images parallels``
     image: ubuntu-12.04-x86_64
-

--- a/doc/topics/profiles.rst
+++ b/doc/topics/profiles.rst
@@ -2,7 +2,7 @@ VM Profiles
 ===========
 
 Salt cloud designates virtual machines inside the profile configuration file.
-The profile configuration file defaults to ``/etc/salt/cloud.profiles`` and is
+The profile configuration file defaults to ``/etc/salt/cloud.profiles`` and is 
 a yaml configuration. The syntax for declaring profiles is simple:
 
 .. code-block:: yaml
@@ -13,7 +13,8 @@ a yaml configuration. The syntax for declaring profiles is simple:
         size: 256 server
         script: Fedora
 
-A few key peices of information need to be declared and can change based on the
+
+A few key pieces of information need to be declared and can change based on the
 public cloud provider. A number of additional parameters can also be inserted:
 
 .. code-block:: yaml
@@ -29,6 +30,7 @@ public cloud provider. A number of additional parameters can also be inserted:
         grains:
             role: webserver
 
+
 The image must be selected from available images. Similarly, sizes must be
 selected from the list of sizes. To get a list of available images and sizes
 use the following command:
@@ -38,18 +40,23 @@ use the following command:
     salt-cloud --list-images openstack
     salt-cloud --list-sizes openstack
 
-Some parameters can be specified in the main Salt cloud config file and then
-are applied to all cloud profiles. For instance if only a single cloud provider
-is being used then the provider option can be declared in the Salt cloud config
-file.
 
-Multiple Config Files
----------------------
+Some parameters can be specified in the main Salt cloud configuration file and 
+then are applied to all cloud profiles. For instance if only a single cloud 
+provider is being used then the provider option can be declared in the Salt 
+cloud configuration file.
+
+
+Multiple Configuration Files
+----------------------------
 
 In addition to ``/etc/salt/cloud.profiles``, profiles can also be specified in
-any file matching ``/etc/salt/cloud.profiles.d/*conf``. This allows for more
+any file matching ``cloud.profiles.d/*conf`` which is a sub-directory relative 
+to the profiles configuration file(with the above configuration file as an 
+example, ``/etc/salt/cloud.profiles.d/*.conf``).  This allows for more 
 extensible configuration, and plays nicely with various configuration
 management tools as well as version control systems.
+
 
 Larger Example
 --------------

--- a/doc/topics/rackspace.rst
+++ b/doc/topics/rackspace.rst
@@ -12,7 +12,7 @@ that Salt Cloud has been built to support.
     # Set the location of the salt-master
     #
     minion:
-        master: saltmaster.example.com
+      master: saltmaster.example.com
 
     # Configure Rackspace using the OpenStack plugin
     #
@@ -58,6 +58,8 @@ that Salt Cloud has been built to support.
       user: myname
       tenant: 123456
       apikey: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+      provider: rackspace
 
 
 

--- a/doc/topics/rackspace.rst
+++ b/doc/topics/rackspace.rst
@@ -2,10 +2,10 @@
 Getting Started With Rackspace
 ==============================
 
-Rackspace is a major public cloud platform and is one of the core platforms
+Rackspace is a major public cloud platform and is one of the core platforms 
 that Salt Cloud has been built to support.
 
-Set up the cloud config at ``/etc/salt/cloud``:
+* Using the old format, set up the cloud configuration at ``/etc/salt/cloud``:
 
 .. code-block:: yaml
 
@@ -31,8 +31,39 @@ Set up the cloud config at ``/etc/salt/cloud``:
     OPENSTACK.apikey: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 
+* Using the new format, set up the cloud configuration at 
+  ``/etc/salt/cloud.providers`` or 
+  ``/etc/salt/cloud.providers.d/rackspace.conf``:
+
+.. code-block:: yaml
+
+    rackspace-config:
+      # Set the location of the salt-master
+      #
+      minion:
+        master: saltmaster.example.com
+
+      # Configure Rackspace using the OpenStack plugin
+      #
+      identity_url: 'https://identity.api.rackspacecloud.com/v2.0/tokens'
+      compute_name: cloudServersOpenStack
+      protocol: ipv4
+
+      # Set the compute region:
+      #
+      compute_region: DFW
+
+      # Configure Rackspace authentication credentials
+      #
+      user: myname
+      tenant: 123456
+      apikey: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+
 Compute Region
 ==============
+
 Rackspace currently has three compute regions which may be used:
 
 .. code-block::
@@ -49,12 +80,17 @@ Note: if you are using LON with a UK account, you must use the following identit
 
 Authentication
 ==============
-The ``user`` is the same user as is used to log into the Rackspace Control
-Panel. The ``tenant`` and ``apikey`` can be found in the API Keys area of the
-Control Panel. The ``apikey`` will be labeled as API Key (and may need to be
+
+The ``user`` is the same user as is used to log into the Rackspace Control 
+Panel. The ``tenant`` and ``apikey`` can be found in the API Keys area of the 
+Control Panel. The ``apikey`` will be labeled as API Key (and may need to be 
 generated), and ``tenant`` will be labeled as Cloud Account Number.
 
-An initial profile will be configured in ``/etc/salt/cloud.profiles``:
+An initial profile can be configured in ``/etc/salt/cloud.profiles`` or 
+``/etc/salt/cloud.profiles.d/openstack.conf``:
+
+
+* Using the old cloud configuration format:
 
 .. code-block:: yaml
 
@@ -63,6 +99,18 @@ An initial profile will be configured in ``/etc/salt/cloud.profiles``:
         size: 512MB Standard Instance
         image: Ubuntu 12.04 LTS (Precise Pangolin)
 
+
+* Using the new cloud configuration format and the example configuration from 
+  above:
+
+.. code-block:: yaml
+
+    openstack_512:
+        provider: openstack-config
+        size: 512MB Standard Instance
+        image: Ubuntu 12.04 LTS (Precise Pangolin)
+
+
 To instantiate a machine based on this profile:
 
 .. code-block:: bash
@@ -70,10 +118,10 @@ To instantiate a machine based on this profile:
     # salt-cloud -p openstack_512 myinstance
 
 This will create a virtual machine at Rackspace with the name ``myinstance``.
-This operation may take several minutes to complete, depending on the current
+This operation may take several minutes to complete, depending on the current 
 load at the Rackspace data center.
 
-Once the instance has been created with salt-minion installed, connectivity to
+Once the instance has been created with salt-minion installed, connectivity to 
 it can be verified with Salt:
 
 .. code-block:: bash

--- a/doc/topics/rackspace.rst
+++ b/doc/topics/rackspace.rst
@@ -74,11 +74,21 @@ Rackspace currently has three compute regions which may be used:
     ORD -> Chicago
     LON -> London
 
-Note: if you are using LON with a UK account, you must use the following identity_url:
+Note: if you are using LON with a UK account, using the old cloud providers 
+syntax, you must use the following identity_url:
 
 .. code-block:: yaml
 
     OPENSTACK.identity_url: 'https://lon.identity.api.rackspacecloud.com/v2.0/tokens'
+
+
+And using the new cloud providers syntax:
+
+.. code-block:: yaml
+
+    my-openstack-config:
+      identity_url: 'https://lon.identity.api.rackspacecloud.com/v2.0/tokens'
+
 
 Authentication
 ==============

--- a/doc/topics/rackspace.rst
+++ b/doc/topics/rackspace.rst
@@ -37,7 +37,7 @@ that Salt Cloud has been built to support.
 
 .. code-block:: yaml
 
-    rackspace-config:
+    my-rackspace-config:
       # Set the location of the salt-master
       #
       minion:
@@ -108,7 +108,7 @@ An initial profile can be configured in ``/etc/salt/cloud.profiles`` or
 .. code-block:: yaml
 
     openstack_512:
-        provider: openstack-config
+        provider: my-openstack-config
         size: 512MB Standard Instance
         image: Ubuntu 12.04 LTS (Precise Pangolin)
 

--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -115,7 +115,7 @@ class SaltCloud(parsers.SaltCloudParser):
                 except SaltCloudSystemExit as exc:
                     self.exit(exc.exit_code, exc.message)
                 except Exception as exc:
-                    self.error(
+                    log.error(
                         'There was an error listing providers: {0}'.format(
                             exc
                         ),
@@ -133,7 +133,7 @@ class SaltCloud(parsers.SaltCloudParser):
                 except SaltCloudSystemExit as exc:
                     self.exit(exc.exit_code, exc.message)
                 except Exception as exc:
-                    self.error(
+                    log.error(
                         'There was an error with a custom map: {0}'.format(
                             exc
                         ),
@@ -150,7 +150,7 @@ class SaltCloud(parsers.SaltCloudParser):
                 except SaltCloudSystemExit as exc:
                     self.exit(exc.exit_code, exc.message)
                 except Exception as exc:
-                    self.error(
+                    log.error(
                         'There was an error with a map: {0}'.format(
                             exc
                         ),
@@ -168,7 +168,7 @@ class SaltCloud(parsers.SaltCloudParser):
             except SaltCloudSystemExit as exc:
                 self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                self.error(
+                log.error(
                     'There was an error listing locations: {0}'.format(exc),
                     # Show the traceback if the debug logging level is enabled
                     exc_info=log.isEnabledFor(logging.DEBUG)
@@ -183,7 +183,7 @@ class SaltCloud(parsers.SaltCloudParser):
             except SaltCloudSystemExit as exc:
                 self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                self.error(
+                log.error(
                     'There was an error listing images: {0}'.format(exc),
                     # Show the traceback if the debug logging level is enabled
                     exc_info=log.isEnabledFor(logging.DEBUG)
@@ -198,7 +198,7 @@ class SaltCloud(parsers.SaltCloudParser):
             except SaltCloudSystemExit as exc:
                 self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                self.error(
+                log.error(
                     'There was an error listing sizes: {0}'.format(exc),
                     # Show the traceback if the debug logging level is enabled
                     exc_info=log.isEnabledFor(logging.DEBUG)
@@ -223,7 +223,7 @@ class SaltCloud(parsers.SaltCloudParser):
             except SaltCloudSystemExit as exc:
                 self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                self.error(
+                log.error(
                     'There was an error destroying machines: {0}'.format(exc),
                     # Show the traceback if the debug logging level is enabled
                     exc_info=log.isEnabledFor(logging.DEBUG)
@@ -262,7 +262,7 @@ class SaltCloud(parsers.SaltCloudParser):
             except SaltCloudSystemExit as exc:
                 self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                self.error(
+                log.error(
                     'There was an error actioning machines: {0}'.format(exc),
                     # Show the traceback if the debug logging level is enabled
                     exc_info=log.isEnabledFor(logging.DEBUG)
@@ -295,7 +295,7 @@ class SaltCloud(parsers.SaltCloudParser):
             except SaltCloudSystemExit as exc:
                 self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                self.error(
+                log.error(
                     'There was an error running the function: {0}'.format(exc),
                     # Show the traceback if the debug logging level is enabled
                     exc_info=log.isEnabledFor(logging.DEBUG)
@@ -308,7 +308,7 @@ class SaltCloud(parsers.SaltCloudParser):
             except SaltCloudSystemExit as exc:
                 self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                self.error(
+                log.error(
                     'There was a profile error: {0}'.format(exc),
                     # Show the traceback if the debug logging level is enabled
                     exc_info=log.isEnabledFor(logging.DEBUG)
@@ -346,7 +346,7 @@ class SaltCloud(parsers.SaltCloudParser):
             except SaltCloudSystemExit as exc:
                 self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                self.error(
+                log.error(
                     'There was a query error: {0}'.format(exc),
                     # Show the traceback if the debug logging level is enabled
                     exc_info=log.isEnabledFor(logging.DEBUG)

--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -113,7 +113,10 @@ class SaltCloud(parsers.SaltCloudParser):
                         mapper.provider_list()
                     )
                 except SaltCloudSystemExit as exc:
-                    self.exit(exc.exit_code, exc.message)
+                    self.exit(
+                        exc.exit_code,
+                        'Error: {0}\n'.format(exc.message.rstrip())
+                    )
                 except Exception as exc:
                     log.error(
                         'There was an error listing providers: {0}'.format(
@@ -131,7 +134,10 @@ class SaltCloud(parsers.SaltCloudParser):
                         query=self.selected_query_option
                     )
                 except SaltCloudSystemExit as exc:
-                    self.exit(exc.exit_code, exc.message)
+                    self.exit(
+                        exc.exit_code,
+                        'Error: {0}\n'.format(exc.message.rstrip())
+                    )
                 except Exception as exc:
                     log.error(
                         'There was an error with a custom map: {0}'.format(
@@ -148,7 +154,10 @@ class SaltCloud(parsers.SaltCloudParser):
                         query=self.selected_query_option
                     )
                 except SaltCloudSystemExit as exc:
-                    self.exit(exc.exit_code, exc.message)
+                    self.exit(
+                        exc.exit_code,
+                        'Error: {0}\n'.format(exc.message.rstrip())
+                    )
                 except Exception as exc:
                     log.error(
                         'There was an error with a map: {0}'.format(
@@ -166,7 +175,10 @@ class SaltCloud(parsers.SaltCloudParser):
                     mapper.location_list(self.options.list_locations)
                 )
             except SaltCloudSystemExit as exc:
-                self.exit(exc.exit_code, exc.message)
+                self.exit(
+                    exc.exit_code,
+                    'Error: {0}\n'.format(exc.message.rstrip())
+                )
             except Exception as exc:
                 log.error(
                     'There was an error listing locations: {0}'.format(exc),
@@ -181,7 +193,10 @@ class SaltCloud(parsers.SaltCloudParser):
                     mapper.image_list(self.options.list_images)
                 )
             except SaltCloudSystemExit as exc:
-                self.exit(exc.exit_code, exc.message)
+                self.exit(
+                    exc.exit_code,
+                    'Error: {0}\n'.format(exc.message.rstrip())
+                )
             except Exception as exc:
                 log.error(
                     'There was an error listing images: {0}'.format(exc),
@@ -196,7 +211,10 @@ class SaltCloud(parsers.SaltCloudParser):
                     mapper.size_list(self.options.list_sizes)
                 )
             except SaltCloudSystemExit as exc:
-                self.exit(exc.exit_code, exc.message)
+                self.exit(
+                    exc.exit_code,
+                    'Error: {0}\n'.format(exc.message.rstrip())
+                )
             except Exception as exc:
                 log.error(
                     'There was an error listing sizes: {0}'.format(exc),
@@ -221,7 +239,10 @@ class SaltCloud(parsers.SaltCloudParser):
                 if self.print_confirm(msg):
                     ret = mapper.destroy(names)
             except SaltCloudSystemExit as exc:
-                self.exit(exc.exit_code, exc.message)
+                self.exit(
+                    exc.exit_code,
+                    'Error: {0}\n'.format(exc.message.rstrip())
+                )
             except Exception as exc:
                 log.error(
                     'There was an error destroying machines: {0}'.format(exc),
@@ -260,7 +281,10 @@ class SaltCloud(parsers.SaltCloudParser):
                 if self.print_confirm(msg):
                     ret = mapper.do_action(names, kwargs)
             except SaltCloudSystemExit as exc:
-                self.exit(exc.exit_code, exc.message)
+                self.exit(
+                    exc.exit_code,
+                    'Error: {0}\n'.format(exc.message.rstrip())
+                )
             except Exception as exc:
                 log.error(
                     'There was an error actioning machines: {0}'.format(exc),
@@ -293,7 +317,7 @@ class SaltCloud(parsers.SaltCloudParser):
                     self.function_provider, self.function_name, kwargs
                 )
             except SaltCloudSystemExit as exc:
-                self.exit(exc.exit_code, exc.message)
+                self.exit(exc.exit_code, '{0}\n'.format(exc.message.rstrip()))
             except Exception as exc:
                 log.error(
                     'There was an error running the function: {0}'.format(exc),
@@ -306,7 +330,10 @@ class SaltCloud(parsers.SaltCloudParser):
             try:
                 ret = mapper.run_profile()
             except SaltCloudSystemExit as exc:
-                self.exit(exc.exit_code, exc.message)
+                self.exit(
+                    exc.exit_code,
+                    'Error: {0}\n'.format(exc.message.rstrip())
+                )
             except Exception as exc:
                 log.error(
                     'There was a profile error: {0}'.format(exc),
@@ -344,7 +371,10 @@ class SaltCloud(parsers.SaltCloudParser):
                     log.info('Complete')
 
             except SaltCloudSystemExit as exc:
-                self.exit(exc.exit_code, exc.message)
+                self.exit(
+                    exc.exit_code,
+                    'Error: {0}\n'.format(exc.message.rstrip())
+                )
             except Exception as exc:
                 log.error(
                     'There was a query error: {0}'.format(exc),

--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -17,15 +17,16 @@ import getpass
 import logging
 
 # Import salt libs
-import saltcloud.config
-import saltcloud.output
 import salt.config
 import salt.output
 import salt.utils
 from salt.utils.verify import verify_env, verify_files
 
 # Import saltcloud libs
+import saltcloud.config
+import saltcloud.output
 from saltcloud.utils import parsers
+from saltcloud.exceptions import SaltCloudSystemExit
 from saltcloud.libcloudfuncs import libcloud_version
 
 
@@ -111,12 +112,16 @@ class SaltCloud(parsers.SaltCloudParser):
                     saltcloud.output.double_layer(
                         mapper.provider_list()
                     )
+                except SaltCloudSystemExit as exc:
+                    self.exit(exc.exit_code, exc.message)
                 except Exception as exc:
-                    log.debug(
-                        'There was an error listing providers.', exc_info=True
-                    )
                     self.error(
-                        'There was an error listing providers: {0}'.format(exc)
+                        'There was an error listing providers: {0}'.format(
+                            exc
+                        ),
+                        # Show the traceback if the debug logging level is
+                        # enabled
+                        exc_info=log.isEnabledFor(logging.DEBUG)
                     )
                     self.exit(1)
             if self.config.get('map', None):
@@ -125,14 +130,16 @@ class SaltCloud(parsers.SaltCloudParser):
                     ret = mapper.interpolated_map(
                         query=self.selected_query_option
                     )
+                except SaltCloudSystemExit as exc:
+                    self.exit(exc.exit_code, exc.message)
                 except Exception as exc:
-                    log.debug(
-                        'There was an error with a custom map.', exc_info=True
-                    )
                     self.error(
                         'There was an error with a custom map: {0}'.format(
                             exc
-                        )
+                        ),
+                        # Show the traceback if the debug logging level is
+                        # enabled
+                        exc_info=log.isEnabledFor(logging.DEBUG)
                     )
                     self.exit(1)
             else:
@@ -140,10 +147,16 @@ class SaltCloud(parsers.SaltCloudParser):
                     ret = mapper.map_providers(
                         query=self.selected_query_option
                     )
+                except SaltCloudSystemExit as exc:
+                    self.exit(exc.exit_code, exc.message)
                 except Exception as exc:
-                    log.debug('There was an error with a map.', exc_info=True)
                     self.error(
-                        'There was an error with a map: {0}'.format(exc)
+                        'There was an error with a map: {0}'.format(
+                            exc
+                        ),
+                        # Show the traceback if the debug logging level is
+                        # enabled
+                        exc_info=log.isEnabledFor(logging.DEBUG)
                     )
                     self.exit(1)
 
@@ -152,12 +165,13 @@ class SaltCloud(parsers.SaltCloudParser):
                 saltcloud.output.double_layer(
                     mapper.location_list(self.options.list_locations)
                 )
+            except SaltCloudSystemExit as exc:
+                self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                log.debug(
-                    'There was an error listing locations.', exc_info=True
-                )
                 self.error(
-                    'There was an error listing locations: {0}'.format(exc)
+                    'There was an error listing locations: {0}'.format(exc),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info=log.isEnabledFor(logging.DEBUG)
                 )
                 self.exit(1)
 
@@ -166,10 +180,13 @@ class SaltCloud(parsers.SaltCloudParser):
                 saltcloud.output.double_layer(
                     mapper.image_list(self.options.list_images)
                 )
+            except SaltCloudSystemExit as exc:
+                self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                log.debug('There was an error listing images.', exc_info=True)
                 self.error(
-                    'There was an error listing images: {0}'.format(exc)
+                    'There was an error listing images: {0}'.format(exc),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info=log.isEnabledFor(logging.DEBUG)
                 )
                 self.exit(1)
 
@@ -178,10 +195,13 @@ class SaltCloud(parsers.SaltCloudParser):
                 saltcloud.output.double_layer(
                     mapper.size_list(self.options.list_sizes)
                 )
+            except SaltCloudSystemExit as exc:
+                self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                log.debug('There was an error listing sizes.', exc_info=True)
                 self.error(
-                    'There was an error listing sizes: {0}'.format(exc)
+                    'There was an error listing sizes: {0}'.format(exc),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info=log.isEnabledFor(logging.DEBUG)
                 )
                 self.exit(1)
 
@@ -200,12 +220,13 @@ class SaltCloud(parsers.SaltCloudParser):
             try:
                 if self.print_confirm(msg):
                     ret = mapper.destroy(names)
+            except SaltCloudSystemExit as exc:
+                self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                log.debug(
-                    'There was an error destroying machines.', exc_info=True
-                )
                 self.error(
-                    'There was an error destroy machines: {0}'.format(exc)
+                    'There was an error destroying machines: {0}'.format(exc),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info=log.isEnabledFor(logging.DEBUG)
                 )
                 self.exit(1)
 
@@ -238,12 +259,13 @@ class SaltCloud(parsers.SaltCloudParser):
             try:
                 if self.print_confirm(msg):
                     ret = mapper.do_action(names, kwargs)
+            except SaltCloudSystemExit as exc:
+                self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                log.debug(
-                    'There was a error actioning machines.', exc_info=True
-                )
                 self.error(
-                    'There was an error actioning machines: {0}'.format(exc)
+                    'There was an error actioning machines: {0}'.format(exc),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info=log.isEnabledFor(logging.DEBUG)
                 )
                 self.exit(1)
 
@@ -270,21 +292,27 @@ class SaltCloud(parsers.SaltCloudParser):
                 ret = mapper.do_function(
                     self.function_provider, self.function_name, kwargs
                 )
+            except SaltCloudSystemExit as exc:
+                self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                log.debug(
-                    'There was a error running the function.', exc_info=True
-                )
                 self.error(
-                    'There was an error running the function: {0}'.format(exc)
+                    'There was an error running the function: {0}'.format(exc),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info=log.isEnabledFor(logging.DEBUG)
                 )
                 self.exit(1)
 
         elif self.options.profile and self.config.get('names', False):
             try:
                 ret = mapper.run_profile()
+            except SaltCloudSystemExit as exc:
+                self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                log.debug('There was a profile error.', exc_info=True)
-                self.error('There was a profile error: {0}'.format(exc))
+                self.error(
+                    'There was a profile error: {0}'.format(exc),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info=log.isEnabledFor(logging.DEBUG)
+                )
                 self.exit(1)
 
         elif self.config.get('map', None) and \
@@ -315,9 +343,14 @@ class SaltCloud(parsers.SaltCloudParser):
                 if self.config.get('parallel', False) is False:
                     log.info('Complete')
 
+            except SaltCloudSystemExit as exc:
+                self.exit(exc.exit_code, exc.message)
             except Exception as exc:
-                log.debug('There was a query error.', exc_info=True)
-                self.error('There was a query error: {0}'.format(exc))
+                self.error(
+                    'There was a query error: {0}'.format(exc),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info=log.isEnabledFor(logging.DEBUG)
+                )
                 self.exit(1)
 
         # display output using salt's outputter system

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -57,8 +57,10 @@ class Cloud(object):
             return provider
 
         try:
-            # There's no <alias>:<provider> entry, return the first one
-            return self.opts['providers'][provider][0]['provider']
+            # There's no <alias>:<provider> entry, return the first one if
+            # defined
+            if provider in self.opts['providers']:
+                return self.opts['providers'][provider][0]['provider']
         except Exception, err:
             log.error(
                 'Failed to get the proper cloud provider. '

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -43,6 +43,7 @@ class Cloud(object):
         '''
         if 'provider' in vm_:
             return vm_['provider']
+
         if 'provider' in self.opts:
             if '{0}.create'.format(self.opts['provider']) in self.clouds:
                 return self.opts['provider']
@@ -436,8 +437,9 @@ class Map(Cloud):
         '''
         Read in the specified map file and return the map structure
         '''
-        if not self.opts['map']:
+        if self.opts.get('map', None) is None:
             return {}
+
         if not os.path.isfile(self.opts['map']):
             raise ValueError(
                 'The specified map file does not exist: {0}\n'.format(
@@ -460,6 +462,7 @@ class Map(Cloud):
                 )
             )
             return {}
+
         if 'include' in map_:
             map_ = salt.config.include_config(map_, self.opts['map'])
         return map_

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -4,7 +4,6 @@ correct cloud modules
 '''
 # Import python libs
 import os
-import sys
 import copy
 import glob
 import multiprocessing
@@ -15,6 +14,7 @@ import time
 import saltcloud.utils
 import saltcloud.loader
 import saltcloud.config as config
+from saltcloud.exceptions import SaltCloudSystemExit
 
 # Import salt libs
 import salt.client
@@ -617,11 +617,12 @@ class Map(Cloud):
                 # Look for the items to delete
                 ret['destroy'] = exist.difference(defined)
             else:
-                print('The --hard map can be extremely dangerous to use, and '
-                      'therefore must explicitly be enabled in the main'
-                      'configuration file, by setting enable_hard_maps to '
-                      'True')
-                sys.exit(1)
+                raise SaltCloudSystemExit(
+                    'The --hard map can be extremely dangerous to use, '
+                    'and therefore must explicitly be enabled in the main '
+                    'configuration file, by setting \'enable_hard_maps\' '
+                    'to True'
+                )
         return ret
 
     def run_map(self, dmap):
@@ -649,13 +650,12 @@ class Map(Cloud):
                 master_host = out['deploy_kwargs']['host']
                 output[master_name] = out
             else:
-                print(
+                raise SaltCloudSystemExit(
                     'Host for new master {0} was not found, '
                     'aborting map'.format(
                         master_name
                     )
                 )
-                sys.exit(1)
         except StopIteration:
             log.debug('No make_master found in map')
 

--- a/saltcloud/clouds/botocore_aws.py
+++ b/saltcloud/clouds/botocore_aws.py
@@ -38,6 +38,7 @@ Using the new format, set up the cloud configuration at
       securitygroup: ssh_open
       # The location of the private key which corresponds to the keyname
       private_key: /root/default.pem
+      provider: aws
 
 '''
 

--- a/saltcloud/clouds/botocore_aws.py
+++ b/saltcloud/clouds/botocore_aws.py
@@ -48,10 +48,10 @@ import stat
 import logging
 
 # Import saltcloud libs
-import saltcloud.utils
 import saltcloud.config as config
 from saltcloud.utils import namespaced_function
 from saltcloud.libcloudfuncs import *
+from saltcloud.exceptions import SaltCloudException, SaltCloudSystemExit
 
 # Import libcloud_aws, required to latter patch __opts__
 from saltcloud.clouds import libcloud_aws
@@ -60,9 +60,6 @@ from saltcloud.clouds import libcloud_aws
 PRE_IMPORT_LOCALS_KEYS = locals().copy()
 from saltcloud.clouds.libcloud_aws import *
 POST_IMPORT_LOCALS_KEYS = locals().copy()
-
-# Import salt libs
-from salt.exceptions import SaltException
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -100,7 +97,7 @@ def __virtual__():
             continue
 
         if not os.path.exists(details['private_key']):
-            raise SaltException(
+            raise SaltCloudException(
                 'The AWS key file {0!r} used in the {1!r} provider '
                 'configuration does not exist\n'.format(
                     details['private_key'],
@@ -112,7 +109,7 @@ def __virtual__():
             oct(stat.S_IMODE(os.stat(details['private_key']).st_mode))
         )
         if keymode not in ('0400', '0600'):
-            raise SaltException(
+            raise SaltCloudException(
                 'The AWS key file {0!r} used in the {1!r} provider '
                 'configuration needs to be set to mode 0400 or 0600\n'.format(
                     details['private_key'],
@@ -180,8 +177,9 @@ def enable_term_protect(name, call=None):
         salt-cloud -a enable_term_protect mymachine
     '''
     if call != 'action':
-        print('This action must be called with -a or --action.')
-        sys.exit(1)
+        raise SaltCloudSystemExit(
+            'This action must be called with -a or --action.'
+        )
 
     return _toggle_term_protect(name, True)
 
@@ -195,8 +193,9 @@ def disable_term_protect(name, call=None):
         salt-cloud -a disable_term_protect mymachine
     '''
     if call != 'action':
-        print('This action must be called with -a or --action.')
-        sys.exit(1)
+        raise SaltCloudSystemExit(
+            'This action must be called with -a or --action.'
+        )
 
     return _toggle_term_protect(name, False)
 

--- a/saltcloud/clouds/botocore_aws.py
+++ b/saltcloud/clouds/botocore_aws.py
@@ -27,7 +27,7 @@ Using the new format, set up the cloud configuration at
 
 .. code-block:: yaml
 
-    aws-botocore-config:
+    my-aws-botocore-config:
       # The AWS API authentication id
       id: GKTADJGHEIQSXMKKRBJ08H
       # The AWS API authentication key

--- a/saltcloud/clouds/botocore_aws.py
+++ b/saltcloud/clouds/botocore_aws.py
@@ -58,6 +58,10 @@ def __virtual__():
     except ImportError:
         # Botocore is not available, the Libcloud AWS module will be loaded
         # instead.
+        log.debug(
+            'The \'botocore\' library is not installed. The libcloud AWS '
+            'support will be loaded instead.'
+        )
         return False
 
     # "Patch" the imported libcloud_aws to have the current __opts__

--- a/saltcloud/clouds/botocore_aws.py
+++ b/saltcloud/clouds/botocore_aws.py
@@ -152,7 +152,9 @@ def __virtual__():
     script = namespaced_function(script, globals(), (conn,))
     list_nodes = namespaced_function(list_nodes, globals(), (conn,))
     list_nodes_full = namespaced_function(list_nodes_full, globals(), (conn,))
-    list_nodes_select = namespaced_function(list_nodes_select, globals(), (conn,))
+    list_nodes_select = namespaced_function(
+        list_nodes_select, globals(), (conn,)
+    )
 
     log.debug('Loading AWS botocore cloud module')
     return 'aws'
@@ -210,8 +212,12 @@ def _toggle_term_protect(name, enabled):
     vm_ = get_configured_provider()
     session = botocore.session.get_session()
     session.set_credentials(
-        access_key=config.get_config_value('id', vm_, __opts__),
-        secret_key=config.get_config_value('key', vm_, __opts__)
+        access_key=config.get_config_value(
+            'id', vm_, __opts__, search_global=False
+        ),
+        secret_key=config.get_config_value(
+            'key', vm_, __opts__, search_global=False
+        )
     )
 
     service = session.get_service('ec2')

--- a/saltcloud/clouds/botocore_aws.py
+++ b/saltcloud/clouds/botocore_aws.py
@@ -4,8 +4,9 @@ The AWS Cloud Module
 
 The AWS cloud module is used to interact with the Amazon Web Services system.
 
-To use the AWS cloud module the following configuration parameters need to be
-set in the main cloud config:
+To use the AWS cloud module, using the old cloud providers configuration
+syntax, the following configuration parameters need to be set in the main cloud
+configuration file:
 
 .. code-block:: yaml
 
@@ -19,6 +20,24 @@ set in the main cloud config:
     AWS.securitygroup: ssh_open
     # The location of the private key which corresponds to the keyname
     AWS.private_key: /root/default.pem
+
+
+Using the new format, set up the cloud configuration at
+ ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/aws.conf``:
+
+.. code-block:: yaml
+
+    aws-botocore-config:
+      # The AWS API authentication id
+      id: GKTADJGHEIQSXMKKRBJ08H
+      # The AWS API authentication key
+      key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+      # The ssh keyname to use
+      keyname: default
+      # The amazon security group
+      securitygroup: ssh_open
+      # The location of the private key which corresponds to the keyname
+      private_key: /root/default.pem
 
 '''
 

--- a/saltcloud/clouds/digital_ocean.py
+++ b/saltcloud/clouds/digital_ocean.py
@@ -31,21 +31,16 @@ Using the new format, set up the cloud configuration at
 '''
 
 # Import python libs
-import re
-import sys
 import time
-import yaml
 import json
 import urllib
 import urllib2
 import logging
 
-# Import salt libs
-import salt.utils.event
-
 # Import salt cloud libs
 import saltcloud.utils
 import saltcloud.config as config
+from saltcloud.exceptions import SaltCloudSystemExit
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -354,10 +349,9 @@ def show_instance(name, call=None):
     Show the details from Digital Ocean concerning a droplet
     '''
     if call != 'action':
-        log.error(
+        raise SaltCloudSystemExit(
             'The show_instance action must be called with -a or --action.'
         )
-        sys.exit(1)
 
     return _get_node(name)
 

--- a/saltcloud/clouds/digital_ocean.py
+++ b/saltcloud/clouds/digital_ocean.py
@@ -40,7 +40,7 @@ import logging
 # Import salt cloud libs
 import saltcloud.utils
 import saltcloud.config as config
-from saltcloud.exceptions import SaltCloudSystemExit
+from saltcloud.exceptions import SaltCloudNotFound, SaltCloudSystemExit
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -172,7 +172,7 @@ def get_image(vm_):
     for image in images:
         if vm_image in (images[image]['name'], images[image]['id']):
             return images[image]['id']
-    raise ValueError('The specified image could not be found.')
+    raise SaltCloudNotFound('The specified image could not be found.')
 
 
 def get_size(vm_):
@@ -186,7 +186,7 @@ def get_size(vm_):
     for size in sizes:
         if vm_size in (sizes[size]['name'], sizes[size]['id']):
             return sizes[size]['id']
-    raise ValueError('The specified size could not be found.')
+    raise SaltCloudNotFound('The specified size could not be found.')
 
 
 def get_location(vm_):
@@ -202,7 +202,7 @@ def get_location(vm_):
         if vm_location in (locations[location]['name'],
                            locations[location]['id']):
             return locations[location]['id']
-    raise ValueError('The specified location could not be found.')
+    raise SaltCloudNotFound('The specified location could not be found.')
 
 
 def create_node(args):
@@ -429,7 +429,7 @@ def get_keyid(keyname):
     keyid = keypairs[keyname]['id']
     if keyid:
         return keyid
-    raise ValueError('The specified ssh key could not be found.')
+    raise SaltCloudNotFound('The specified ssh key could not be found.')
 
 
 def destroy(name, call=None):

--- a/saltcloud/clouds/digital_ocean.py
+++ b/saltcloud/clouds/digital_ocean.py
@@ -57,13 +57,13 @@ def __virtual__():
     Check for Digital Ocean configurations
     '''
     if get_configured_provider() is False:
-        log.info(
+        log.debug(
             'There is no Digital Ocean cloud provider configuration '
             'available. Not loading module'
         )
         return False
 
-    log.debug('Loading Digital Ocean cloud module')
+    log.info('Loading Digital Ocean cloud module')
     return 'digital_ocean'
 
 

--- a/saltcloud/clouds/digital_ocean.py
+++ b/saltcloud/clouds/digital_ocean.py
@@ -26,7 +26,7 @@ Using the new format, set up the cloud configuration at
       # Digital Ocean account keys
       client_key: wFGEwgregeqw3435gDger
       api_key: GDE43t43REGTrkilg43934t34qT43t4dgegerGEgg
-
+      provider: digital_ocean
 
 '''
 

--- a/saltcloud/clouds/digital_ocean.py
+++ b/saltcloud/clouds/digital_ocean.py
@@ -67,7 +67,7 @@ def get_configured_provider():
     Return the first configured instance.
     '''
     return config.is_provider_configured(
-        __opts__, 'digital_ocean', ('apikey',)
+        __opts__, 'digital_ocean', ('api_key',)
     )
 
 

--- a/saltcloud/clouds/digital_ocean.py
+++ b/saltcloud/clouds/digital_ocean.py
@@ -315,10 +315,10 @@ def query(method='droplets', droplet_id=None, command=None, args=None):
         args = {}
 
     args['client_id'] = config.get_config_value(
-        'client_key', vm_, __opts__, search_global=False
+        'client_key', get_configured_provider(), __opts__, search_global=False
     )
     args['api_key'] = config.get_config_value(
-        'api_key', vm_, __opts__, search_global=False
+        'api_key', get_configured_provider(), __opts__, search_global=False
     )
 
     path += '?%s'

--- a/saltcloud/clouds/digital_ocean.py
+++ b/saltcloud/clouds/digital_ocean.py
@@ -237,7 +237,7 @@ def create(vm_):
     }
 
     try:
-        data = create_node(kwargs)
+        ret = create_node(kwargs)
     except Exception as exc:
         log.error(
             'Error creating {0} on DIGITAL_OCEAN\n\n'
@@ -275,11 +275,10 @@ def create(vm_):
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
             'keep_tmp': __opts__['keep_tmp'],
+            'script_args': config.get_config_value(
+                'script_args', vm_, __opts__
+            )
         }
-
-        deploy_kwargs['script_args'] = config.get_config_value(
-            'script_args', vm_, __opts__
-        )
 
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(
             __opts__, vm_
@@ -288,6 +287,8 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
+            if __opts__.get('show_deploy_args', False) is True:
+                ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(
@@ -300,7 +301,7 @@ def create(vm_):
             vm_['name']
         )
     )
-    return data
+    return ret
 
 
 def query(method='droplets', droplet_id=None, command=None, args=None):

--- a/saltcloud/clouds/digital_ocean.py
+++ b/saltcloud/clouds/digital_ocean.py
@@ -22,7 +22,7 @@ Using the new format, set up the cloud configuration at
 
 .. code-block:: yaml
 
-    digital-ocean-config:
+    my-digital-ocean-config:
       # Digital Ocean account keys
       client_key: wFGEwgregeqw3435gDger
       api_key: GDE43t43REGTrkilg43934t34qT43t4dgegerGEgg

--- a/saltcloud/clouds/digital_ocean.py
+++ b/saltcloud/clouds/digital_ocean.py
@@ -59,11 +59,11 @@ def __virtual__():
     if get_configured_provider() is False:
         log.debug(
             'There is no Digital Ocean cloud provider configuration '
-            'available. Not loading module'
+            'available. Not loading module.'
         )
         return False
 
-    log.info('Loading Digital Ocean cloud module')
+    log.debug('Loading Digital Ocean cloud module')
     return 'digital_ocean'
 
 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -32,8 +32,7 @@ configuration parameters need to be set in the main cloud configuration:
 
 
 * Using the new format, set up the cloud configuration at
-  ``/etc/salt/cloud.providers`` or
-  ``/etc/salt/cloud.providers.d/parallels.conf``:
+ ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/ec2.conf``:
 
 .. code-block:: yaml
 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -79,7 +79,7 @@ import xml.etree.ElementTree as ET
 
 # Import saltcloud libs
 import saltcloud.utils
-import saltcloud.config
+import saltcloud.config as config
 from saltcloud.libcloudfuncs import *
 
 # Import salt libs
@@ -148,7 +148,7 @@ def __virtual__():
 
 
 def get_configured_provider():
-    return saltcloud.config.is_provider_configured(
+    return config.is_provider_configured(
         __opts__,
         'ec2',
         ('id', 'key', 'keyname', 'securitygroup', 'private_key')
@@ -453,21 +453,21 @@ def keyname(vm_):
     '''
     Return the keyname
     '''
-    return saltcloud.config.get_config_value('keyname', vm_, __opts__)
+    return config.get_config_value('keyname', vm_, __opts__)
 
 
 def securitygroup(vm_):
     '''
     Return the security group
     '''
-    return saltcloud.config.get_config_value('securitygroup', vm_, __opts__)
+    return config.get_config_value('securitygroup', vm_, __opts__)
 
 
 def ssh_username(vm_):
     '''
     Return the ssh_username. Defaults to a built-in list of users for trying.
     '''
-    usernames = saltcloud.config.get_config_value(
+    usernames = config.get_config_value(
         'ssh_username', vm_, __opts__
     )
 
@@ -489,7 +489,7 @@ def ssh_interface(vm_):
     Return the ssh_interface type to connect to. Either 'public_ips' (default)
     or 'private_ips'.
     '''
-    return saltcloud.config.get_config_value(
+    return config.get_config_value(
         'ssh_interface', vm_, __opts__, default='public_ips'
     )
 
@@ -503,7 +503,7 @@ def get_location(vm_=None):
     '''
     return __opts__.get(
         'location',
-        saltcloud.config.get_config_value(
+        config.get_config_value(
             'location', vm_, __opts__, default=DEFAULT_LOCATION)
     )
 
@@ -530,7 +530,7 @@ def get_availability_zone(vm_):
     '''
     Return the availability zone to use
     '''
-    avz = saltcloud.config.get_config_value(
+    avz = config.get_config_value(
         'ssh_username', vm_, __opts__, default=None
     )
 
@@ -611,7 +611,7 @@ def create(vm_=None, call=None):
     if az is not None:
         params['Placement.AvailabilityZone'] = az
 
-    delvol_on_destroy = saltcloud.config.get_config_value(
+    delvol_on_destroy = config.get_config_value(
         'delvol_on_destroy', vm_, __opts__, default=None
     )
 
@@ -666,7 +666,7 @@ def create(vm_=None, call=None):
         for user in usernames:
             if saltcloud.utils.wait_for_passwd(
                     host=ip_address, username=user, ssh_timeout=60,
-                    key_filename=saltcloud.config.get_config_value(
+                    key_filename=config.get_config_value(
                         'private_key', vm_, __opts__)):
                 username = user
                 break
@@ -674,19 +674,19 @@ def create(vm_=None, call=None):
             return {vm_['name']: 'Failed to authenticate'}
 
     ret = {}
-    if saltcloud.config.get_config_value('deploy', vm_, __opts__) is True:
+    if config.get_config_value('deploy', vm_, __opts__) is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
             'host': ip_address,
             'username': username,
-            'key_filename': saltcloud.config.get_config_value(
+            'key_filename': config.get_config_value(
                 'private_key', vm_, __opts__
             ),
             'deploy_command': 'sh /tmp/deploy.sh',
             'tty': True,
             'script': deploy_script,
             'name': vm_['name'],
-            'sudo': saltcloud.config.get_config_value(
+            'sudo': config.get_config_value(
                 'sudo', vm_, __opts__, default=(username != 'root')
             ),
             'start_action': __opts__['start_action'],
@@ -697,7 +697,7 @@ def create(vm_=None, call=None):
             'keep_tmp': __opts__['keep_tmp'],
         }
 
-        deploy_kwargs['display_ssh_output'] = saltcloud.config.get_config_value(
+        deploy_kwargs['display_ssh_output'] = config.get_config_value(
             'display_ssh_output', vm_, __opts__, default=True
         )
 
@@ -705,12 +705,12 @@ def create(vm_=None, call=None):
             __opts__, vm_
         )
 
-        deploy_kwargs['script_args'] = saltcloud.config.get_config_value(
+        deploy_kwargs['script_args'] = config.get_config_value(
             'script_args', vm_, __opts__
         )
 
         # Deploy salt-master files, if necessary
-        if saltcloud.config.get_config_value('make_master', vm_, __opts__) is True:
+        if config.get_config_value('make_master', vm_, __opts__) is True:
             deploy_kwargs['make_master'] = True
             deploy_kwargs['master_pub'] = vm_['master_pub']
             deploy_kwargs['master_pem'] = vm_['master_pem']
@@ -953,7 +953,7 @@ def destroy(name, call=None):
                   'salt-cloud -a disable_term_protect {0}'.format(name))
         exit(1)
 
-    if saltcloud.config.get_config_value(
+    if config.get_config_value(
             'display_ssh_output', get_configured_provider(), __opts__) is True:
         newname = '{0}-DEL{1}'.format(name, uuid.uuid4().hex)
         rename(name, kwargs={'newname': newname}, call='action')

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -109,7 +109,7 @@ size_map = {
 # Only load in this module if the EC2 configurations are in place
 def __virtual__():
     '''
-    Set up the libcloud funcstions and check for EC2 configs
+    Set up the libcloud functions and check for EC2 configurations
     '''
     if get_configured_provider() is False:
         log.info(
@@ -119,7 +119,7 @@ def __virtual__():
         return False
 
     for provider, details in __opts__['providers'].iteritems():
-        if details['provider'] != 'ec2':
+        if 'provider' not in details or details['provider'] != 'ec2':
             continue
 
         if not os.path.exists(details['private_key']):

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -440,14 +440,8 @@ def script(vm_):
     '''
     minion = saltcloud.utils.minion_conf_string(__opts__, vm_)
     script = saltcloud.utils.os_script(
-        saltcloud.utils.get_option(
-            'script',
-            __opts__,
-            vm_
-        ),
-        vm_,
-        __opts__,
-        minion,
+        config.get_config_value('script', vm_, __opts__),
+        vm_, __opts__, minion
     )
     return script
 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -129,7 +129,7 @@ def __virtual__():
     Set up the libcloud functions and check for EC2 configurations
     '''
     if get_configured_provider() is False:
-        log.info(
+        log.debug(
             'There is no EC2 cloud provider configuration available. Not '
             'loading module'
         )

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -529,7 +529,10 @@ def get_location(vm_=None):
     return __opts__.get(
         'location',
         config.get_config_value(
-            'location', vm_, __opts__, default=DEFAULT_LOCATION,
+            'location',
+            vm_ or get_configured_provider(),
+            __opts__,
+            default=DEFAULT_LOCATION,
             #search_global=False
         )
     )

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -138,7 +138,7 @@ def __virtual__():
             raise SaltException(
                 'The EC2 key file {0!r} used in the {1!r} provider '
                 'configuration needs to be set to mode 0400 or 0600\n'.format(
-                    __opts__['EC2.private_key'],
+                    details['private_key'],
                     provider
                 )
             )
@@ -148,6 +148,9 @@ def __virtual__():
 
 
 def get_configured_provider():
+    '''
+    Return the first configured instance.
+    '''
     return config.is_provider_configured(
         __opts__,
         'ec2',
@@ -954,7 +957,7 @@ def destroy(name, call=None):
         exit(1)
 
     if config.get_config_value(
-            'display_ssh_output', get_configured_provider(), __opts__) is True:
+            'rename_on_destroy', get_configured_provider(), __opts__) is True:
         newname = '{0}-DEL{1}'.format(name, uuid.uuid4().hex)
         rename(name, kwargs={'newname': newname}, call='action')
         log.info(

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -36,7 +36,7 @@ Using the new format, set up the cloud configuration at
 
 .. code-block:: yaml
 
-    ec2-config:
+    my-ec2-config:
       # The EC2 API authentication id
       id: GKTADJGHEIQSXMKKRBJ08H
       # The EC2 API authentication key

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -31,7 +31,7 @@ configuration parameters need to be set in the main cloud configuration:
     EC2.endpoint: myendpoint.example.com:1138/services/Cloud
 
 
-* Using the new format, set up the cloud configuration at
+Using the new format, set up the cloud configuration at
  ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/ec2.conf``:
 
 .. code-block:: yaml

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -756,7 +756,8 @@ def create(vm_=None, call=None):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {name}'.format(**vm_))
-            ret['deploy_kwargs'] = deploy_kwargs
+            if __opts__.get('show_deploy_args', False) is True:
+                ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error('Failed to start Salt on Cloud VM {name}'.format(**vm_))
 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -83,7 +83,11 @@ import xml.etree.ElementTree as ET
 import saltcloud.utils
 import saltcloud.config as config
 from saltcloud.libcloudfuncs import *
-from saltcloud.exceptions import SaltCloudException, SaltCloudSystemExit
+from saltcloud.exceptions import (
+    SaltCloudException,
+    SaltCloudSystemExit,
+    SaltCloudConfigError
+)
 
 
 # Get logging started
@@ -645,7 +649,9 @@ def create(vm_=None, call=None):
 
     if delvol_on_destroy is not None:
         if not isinstance(delvol_on_destroy, bool):
-            raise ValueError('\'delvol_on_destroy\' should be a boolean value')
+            raise SaltCloudConfigError(
+                '\'delvol_on_destroy\' should be a boolean value.'
+            )
 
         params['BlockDeviceMapping.1.DeviceName'] = '/dev/sda1'
         params['BlockDeviceMapping.1.Ebs.DeleteOnTermination'] = str(

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -942,8 +942,6 @@ def rename(name, kwargs, call=None):
 
     log.info('Renaming {0} to {1}'.format(name, kwargs['newname']))
 
-    instance_id = _get_node(name)['instanceId']
-
     set_tags(name, {'Name': kwargs['newname']}, call='action')
 
     saltcloud.utils.rename_key(
@@ -961,6 +959,7 @@ def destroy(name, call=None):
     '''
     instance_id = _get_node(name)['instanceId']
     protected = show_term_protect(
+        name=name,
         instance_id=instance_id,
         call='action',
         quiet=True
@@ -1265,9 +1264,10 @@ def _toggle_term_protect(name, value):
     params = {'Action': 'ModifyInstanceAttribute',
               'InstanceId': instance_id,
               'DisableApiTermination.Value': value}
-    result = query(params, return_root=True)
 
-    return show_term_protect(name, instance_id, call='action')
+    query(params, return_root=True)
+
+    return show_term_protect(name=name, instance_id=instance_id, call='action')
 
 
 def keepvol_on_destroy(name, call=None):

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -160,7 +160,7 @@ def __virtual__():
                 )
             )
 
-    log.info('Loading EC2 cloud compute module')
+    log.debug('Loading EC2 cloud compute module')
     return 'ec2'
 
 
@@ -316,111 +316,129 @@ def avail_sizes():
                 'cores': '16 (2 x Intel Xeon E5-2670, eight-core with '
                          'hyperthread)',
                 'disk': '3360 GiB (4 x 840 GiB)',
-                'ram': '60.5 GiB'},
+                'ram': '60.5 GiB'
+            },
             'cc1.4xlarge': {
                 'id': 'cc1.4xlarge',
                 'cores': '8 (2 x Intel Xeon X5570, quad-core with '
                          'hyperthread)',
                 'disk': '1690 GiB (2 x 840 GiB)',
-                'ram': '22.5 GiB'},
+                'ram': '22.5 GiB'
             },
+        },
         'Cluster CPU': {
             'cg1.4xlarge': {
                 'id': 'cg1.4xlarge',
                 'cores': '8 (2 x Intel Xeon X5570, quad-core with '
                          'hyperthread), plus 2 NVIDIA Tesla M2050 GPUs',
                 'disk': '1680 GiB (2 x 840 GiB)',
-                'ram': '22.5 GiB'},
+                'ram': '22.5 GiB'
             },
+        },
         'High CPU': {
             'c1.xlarge': {
                 'id': 'c1.xlarge',
                 'cores': '8 (with 2.5 ECUs each)',
                 'disk': '1680 GiB (4 x 420 GiB)',
-                'ram': '8 GiB'},
+                'ram': '8 GiB'
+            },
             'c1.medium': {
                 'id': 'c1.medium',
                 'cores': '2 (with 2.5 ECUs each)',
                 'disk': '340 GiB (1 x 340 GiB)',
-                'ram': '1.7 GiB'},
+                'ram': '1.7 GiB'
             },
+        },
         'High I/O': {
             'hi1.4xlarge': {
                 'id': 'hi1.4xlarge',
                 'cores': '8 (with 4.37 ECUs each)',
                 'disk': '2 TiB',
-                'ram': '60.5 GiB'},
+                'ram': '60.5 GiB'
             },
+        },
         'High Memory': {
             'm2.2xlarge': {
                 'id': 'm2.2xlarge',
                 'cores': '4 (with 3.25 ECUs each)',
                 'disk': '840 GiB (1 x 840 GiB)',
-                'ram': '34.2 GiB'},
+                'ram': '34.2 GiB'
+            },
             'm2.xlarge': {
                 'id': 'm2.xlarge',
                 'cores': '2 (with 3.25 ECUs each)',
                 'disk': '410 GiB (1 x 410 GiB)',
-                'ram': '17.1 GiB'},
+                'ram': '17.1 GiB'
+            },
             'm2.4xlarge': {
                 'id': 'm2.4xlarge',
                 'cores': '8 (with 3.25 ECUs each)',
                 'disk': '1680 GiB (2 x 840 GiB)',
-                'ram': '68.4 GiB'},
+                'ram': '68.4 GiB'
             },
+        },
         'High-Memory Cluster': {
             'cr1.8xlarge': {
                 'id': 'cr1.8xlarge',
                 'cores': '16 (2 x Intel Xeon E5-2670, eight-core)',
                 'disk': '240 GiB (2 x 120 GiB SSD)',
-                'ram': '244 GiB'},
+                'ram': '244 GiB'
             },
+        },
         'High Storage': {
             'hs1.8xlarge': {
                 'id': 'hs1.8xlarge',
                 'cores': '16 (8 cores + 8 hyperthreads)',
                 'disk': '48 TiB (24 x 2 TiB hard disk drives)',
-                'ram': '117 GiB'},
+                'ram': '117 GiB'
             },
+        },
         'Micro': {
             't1.micro': {
                 'id': 't1.micro',
                 'cores': '1',
                 'disk': 'EBS',
-                'ram': '615 MiB'},
+                'ram': '615 MiB'
             },
+        },
         'Standard': {
             'm1.xlarge': {
                 'id': 'm1.xlarge',
                 'cores': '4 (with 2 ECUs each)',
                 'disk': '1680 GB (4 x 420 GiB)',
-                'ram': '15 GiB'},
+                'ram': '15 GiB'
+            },
             'm1.large': {
                 'id': 'm1.large',
                 'cores': '2 (with 2 ECUs each)',
                 'disk': '840 GiB (2 x 420 GiB)',
-                'ram': '7.5 GiB'},
+                'ram': '7.5 GiB'
+            },
             'm1.medium': {
                 'id': 'm1.medium',
                 'cores': '1',
                 'disk': '400 GiB',
-                'ram': '3.75 GiB'},
+                'ram': '3.75 GiB'
+            },
             'm1.small': {
                 'id': 'm1.small',
                 'cores': '1',
                 'disk': '150 GiB',
-                'ram': '1.7 GiB'},
+                'ram': '1.7 GiB'
+            },
             'm3.2xlarge': {
                 'id': 'm3.2xlarge',
                 'cores': '8 (with 3.25 ECUs each)',
                 'disk': 'EBS',
-                'ram': '30 GiB'},
+                'ram': '30 GiB'
+            },
             'm3.xlarge': {
                 'id': 'm3.xlarge',
                 'cores': '4 (with 3.25 ECUs each)',
                 'disk': 'EBS',
-                'ram': '15 GiB'},
-            }
+                'ram': '15 GiB'
+            },
+        }
     }
     return sizes
 
@@ -975,6 +993,8 @@ def destroy(name, call=None):
         )
         exit(1)
 
+    ret = {}
+
     if config.get_config_value('rename_on_destroy',
                                get_configured_provider(),
                                __opts__, search_global=False) is True:
@@ -986,13 +1006,15 @@ def destroy(name, call=None):
                 newname
             )
         )
+        ret['newname'] = newname
 
     params = {'Action': 'TerminateInstances',
               'InstanceId.1': instance_id}
     result = query(params)
     log.info(result)
 
-    return result
+    ret.update(result[0])
+    return ret
 
 
 def reboot(name, call=None):

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -57,6 +57,8 @@ Using the new format, set up the cloud configuration at
       # can explicitly define the endpoint:
       endpoint: myendpoint.example.com:1138/services/Cloud
 
+      provider: ec2
+
 '''
 
 # Import python libs

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -5,8 +5,8 @@ The EC2 Cloud Module
 The EC2 cloud module is used to interact with the Amazon Elastic Cloud
 Computing. This driver is highly experimental! Use at your own risk!
 
-To use the EC2 cloud module the following configuration parameters need to be
-set in the main cloud config:
+To use the EC2 cloud module, when using the old format the following
+configuration parameters need to be set in the main cloud configuration:
 
 .. code-block:: yaml
 
@@ -29,6 +29,34 @@ set in the main cloud config:
     # and the service_url. If you would like to override that entirely, you can
     # explicitly define the endpoint:
     EC2.endpoint: myendpoint.example.com:1138/services/Cloud
+
+
+* Using the new format, set up the cloud configuration at
+  ``/etc/salt/cloud.providers`` or
+  ``/etc/salt/cloud.providers.d/parallels.conf``:
+
+.. code-block:: yaml
+
+    ec2-config:
+      # The EC2 API authentication id
+      id: GKTADJGHEIQSXMKKRBJ08H
+      # The EC2 API authentication key
+      key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+      # The ssh keyname to use
+      keyname: default
+      # The amazon security group
+      securitygroup: ssh_open
+      # The location of the private key which corresponds to the keyname
+      private_key: /root/default.pem
+
+      # Be default, service_url is set to amazonaws.com. If you are using this
+      # driver for something other than Amazon EC2, change it here:
+      service_url: amazonaws.com
+
+      # The endpoint that is ultimately used is usually formed using the region
+      # and the service_url. If you would like to override that entirely, you
+      # can explicitly define the endpoint:
+      endpoint: myendpoint.example.com:1138/services/Cloud
 
 '''
 

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -168,7 +168,8 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
-            ret['deploy_kwargs'] = deploy_kwargs
+            if __opts__.get('show_deploy_args', False) is True:
+                ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -67,7 +67,7 @@ def __virtual__():
     Set up the libcloud functions and check for GOGRID configs
     '''
     if get_configured_provider() is False:
-        log.info(
+        log.debug(
             'There is no GoGrid cloud provider configuration available. Not '
             'loading module.'
         )

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -52,6 +52,8 @@ log = logging.getLogger(__name__)
 # Some of the libcloud functions need to be in the same namespace as the
 # functions defined in the module, so we create new function objects inside
 # this module namespace
+get_size = namespaced_function(get_size, globals())
+get_image = namespaced_function(get_image, globals())
 avail_images = namespaced_function(avail_images, globals())
 avail_sizes = namespaced_function(avail_sizes, globals())
 script = namespaced_function(script, globals())

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -19,7 +19,7 @@ configuration file to enable interfacing with GoGrid:
     GOGRID.sharedsecret: saltybacon
 
 
-* Using the new format, set up the cloud configuration at
+Using the new format, set up the cloud configuration at
 ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/gogrid.conf``:
 
 .. code-block:: yaml
@@ -65,6 +65,10 @@ def __virtual__():
     Set up the libcloud functions and check for GOGRID configs
     '''
     if get_configured_provider() is False:
+        log.info(
+            'There is no GoGrid cloud provider configuration available. Not '
+            'loading module'
+        )
         return False
 
     log.debug('Loading GoGrid cloud module')

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -24,7 +24,7 @@ Using the new format, set up the cloud configuration at
 
 .. code-block:: yaml
 
-    gogrid-config:
+    my-gogrid-config:
       # The generated api key to use
       apikey: asdff7896asdh789
       # The apikey's shared secret

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -69,7 +69,7 @@ def __virtual__():
     if get_configured_provider() is False:
         log.info(
             'There is no GoGrid cloud provider configuration available. Not '
-            'loading module'
+            'loading module.'
         )
         return False
 
@@ -93,8 +93,12 @@ def get_conn():
     driver = get_driver(Provider.GOGRID)
     vm_ = get_configured_provider()
     return driver(
-        config.get_config_value('apikey', vm_, __opts__),
-        config.get_config_value('sharedsecret', vm_, __opts__)
+        config.get_config_value(
+            'apikey', vm_, __opts__, search_global=False
+        ),
+        config.get_config_value(
+            'sharedsecret', vm_, __opts__, search_global=False
+        )
     )
 
 
@@ -114,8 +118,11 @@ def create(vm_):
         log.error(
             'Error creating {0} on GOGRID\n\n'
             'The following exception was thrown by libcloud when trying to '
-            'run the initial deployment:\n'.format(vm_['name']),
-            exc_info=True
+            'run the initial deployment:\n'.format(
+                vm_['name']
+            ),
+            # Show the traceback if the debug logging level is enabled
+            exc_info=log.isEnabledFor(logging.DEBUG)
         )
         return False
 
@@ -134,11 +141,10 @@ def create(vm_):
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
             'keep_tmp': __opts__['keep_tmp'],
-            }
-
-        deploy_kwargs['script_args'] = config.get_config_value(
-            'script_args', vm_, __opts__
-        )
+            'script_args': config.get_config_value(
+                'script_args', vm_, __opts__
+            )
+        }
 
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(
             __opts__,

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -30,6 +30,8 @@ Using the new format, set up the cloud configuration at
       # The apikey's shared secret
       sharedsecret: saltybacon
 
+      provider: gogrid
+
 '''
 
 # The import section is mostly libcloud boilerplate

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -7,8 +7,9 @@ service. To use Salt Cloud with GoGrid log into the GoGrid web interface and
 create an api key. Do this by clicking on "My Account" and then going to the
 API Keys tab.
 
-The GOGRID.apikey and the GOGRID.sharedsecret configuration paramaters need to
-be set in the config file to enable interfacing with GoGrid
+Using the old providers configuration syntax format, the ``GOGRID.apikey`` and
+the ``GOGRID.sharedsecret`` configuration parameters need to be set in the
+configuration file to enable interfacing with GoGrid:
 
 .. code-block:: yaml
 
@@ -17,18 +18,30 @@ be set in the config file to enable interfacing with GoGrid
     # The apikey's shared secret
     GOGRID.sharedsecret: saltybacon
 
+
+* Using the new format, set up the cloud configuration at
+``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/gogrid.conf``:
+
+.. code-block:: yaml
+
+    gogrid-config:
+      # The generated api key to use
+      apikey: asdff7896asdh789
+      # The apikey's shared secret
+      sharedsecret: saltybacon
+
 '''
 
 # The import section is mostly libcloud boilerplate
 
 # Import python libs
-import sys
 import logging
 
 # Import generic libcloud functions
 from saltcloud.libcloudfuncs import *
 
-# Import salt cloud utils
+# Import salt cloud libs
+import saltcloud.config as config
 from saltcloud.utils import namespaced_function
 
 # Get logging started
@@ -51,18 +64,20 @@ def __virtual__():
     '''
     Set up the libcloud functions and check for GOGRID configs
     '''
-    confs = [
-            'apikey',
-            'sharedsecret',
-            ]
-    for conf in confs:
-        if not __opts__['providers']['gogrid']:
-            return False
-        for provider in __opts__['providers']['gogrid']:
-            if conf not in __opts__['providers']['gogrid'][provider]:
-                return False
+    if get_configured_provider() is False:
+        return False
+
     log.debug('Loading GoGrid cloud module')
     return 'gogrid'
+
+
+def get_configured_provider():
+    '''
+    Return the first configured instance.
+    '''
+    return config.is_provider_configured(
+        __opts__, 'gogrid', ('apikey', 'sharedsecret')
+    )
 
 
 def get_conn():
@@ -70,10 +85,11 @@ def get_conn():
     Return a conn object for the passed VM data
     '''
     driver = get_driver(Provider.GOGRID)
+    vm_ = get_configured_provider()
     return driver(
-            __opts__['GOGRID.apikey'],
-            __opts__['GOGRID.sharedsecret'],
-            )
+        config.get_config_value('apikey', vm_, __opts__),
+        config.get_config_value('sharedsecret', vm_, __opts__)
+    )
 
 
 def create(vm_):
@@ -88,26 +104,17 @@ def create(vm_):
     kwargs['size'] = get_size(conn, vm_)
     try:
         data = conn.create_node(**kwargs)
-    except Exception as exc:
-        message = str(exc)
-        err = ('Error creating {0} on GOGRID\n\n'
-               'The following exception was thrown by libcloud when trying to '
-               'run the initial deployment: \n{1}').format(
-                       vm_['name'], message
-                       )
-        sys.stderr.write(err)
-        log.error(err)
+    except Exception:
+        log.error(
+            'Error creating {0} on GOGRID\n\n'
+            'The following exception was thrown by libcloud when trying to '
+            'run the initial deployment:\n'.format(vm_['name']),
+            exc_info=True
+        )
         return False
 
-    deploy = vm_.get(
-        'deploy',
-        __opts__.get(
-            'GOGRID.deploy',
-            __opts__['deploy']
-        )
-    )
     ret = {}
-    if deploy is True:
+    if config.get_config_value('deploy', vm_, __opts__) is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
             'host': data.public_ips[0],
@@ -123,8 +130,9 @@ def create(vm_):
             'keep_tmp': __opts__['keep_tmp'],
             }
 
-        if 'script_args' in vm_:
-            deploy_kwargs['script_args'] = vm_['script_args']
+        deploy_kwargs['script_args'] = config.get_config_value(
+            'script_args', vm_, __opts__
+        )
 
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(
             __opts__,
@@ -132,7 +140,7 @@ def create(vm_):
         )
 
         # Deploy salt-master files, if necessary
-        if 'make_master' in vm_ and vm_['make_master'] is True:
+        if config.get_config_value('make_master', vm_, __opts__) is True:
             deploy_kwargs['make_master'] = True
             deploy_kwargs['master_pub'] = vm_['master_pub']
             deploy_kwargs['master_pem'] = vm_['master_pem']

--- a/saltcloud/clouds/ibmsce.py
+++ b/saltcloud/clouds/ibmsce.py
@@ -36,6 +36,8 @@ Using the new format, set up the cloud configuration at
       # The ID of the datacenter to use
       location: Raleigh
 
+      provider: ibmsce
+
 
 '''
 

--- a/saltcloud/clouds/ibmsce.py
+++ b/saltcloud/clouds/ibmsce.py
@@ -63,6 +63,8 @@ log = logging.getLogger(__name__)
 # Some of the libcloud functions need to be in the same namespace as the
 # functions defined in the module, so we create new function objects inside
 # this module namespace
+get_size = namespaced_function(get_size, globals())
+get_image = namespaced_function(get_image, globals())
 avail_images = namespaced_function(avail_images, globals())
 avail_sizes = namespaced_function(avail_sizes, globals())
 script = namespaced_function(script, globals())
@@ -80,7 +82,7 @@ def __virtual__():
     if get_configured_provider() is False:
         log.debug(
             'There is no IBM SCE cloud provider configuration available. Not '
-            'loading module'
+            'loading module.'
         )
         return False
 

--- a/saltcloud/clouds/ibmsce.py
+++ b/saltcloud/clouds/ibmsce.py
@@ -26,7 +26,7 @@ Using the new format, set up the cloud configuration at
 
 .. code-block:: yaml
 
-    imbsce-config:
+    my-imbsce-config:
       # The generated api key to use
       user: myuser@mycompany.com
       # The user's password

--- a/saltcloud/clouds/ibmsce.py
+++ b/saltcloud/clouds/ibmsce.py
@@ -222,7 +222,8 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
-            ret['deploy_kwargs'] = deploy_kwargs
+            if __opts__.get('show_deploy_args', False) is True:
+                ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(vm_['name'])

--- a/saltcloud/clouds/ibmsce.py
+++ b/saltcloud/clouds/ibmsce.py
@@ -78,7 +78,7 @@ def __virtual__():
     Set up the libcloud functions and check for RACKSPACE configs
     '''
     if get_configured_provider() is False:
-        log.info(
+        log.debug(
             'There is no IBM SCE cloud provider configuration available. Not '
             'loading module'
         )

--- a/saltcloud/clouds/ibmsce.py
+++ b/saltcloud/clouds/ibmsce.py
@@ -104,7 +104,7 @@ def get_conn():
     vm_ = get_configured_provider()
     driver = get_driver(Provider.IBM)
     return driver(
-        config.get_config_value('user', vm_, __opts__)
+        config.get_config_value('user', vm_, __opts__),
         config.get_config_value('password', vm_, __opts__)
     )
 

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -68,7 +68,7 @@ def __virtual__():
     Set up the libcloud functions and check for JOYENT configs
     '''
     if get_configured_provider() is False:
-        log.info(
+        log.debug(
             'There is no Joyent cloud provider configuration available. Not '
             'loading module.'
         )

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -2,9 +2,10 @@
 Joyent Cloud Module
 ===================
 
-The Joyent Cloud module is used to intereact with the Joyent cloud system
+The Joyent Cloud module is used to interact with the Joyent cloud system.
 
-it requires that the username and password to the joyent accound be configured
+Using the old cloud configuration syntax, it requires that the ``username`` and
+``password`` to the joyent account be configured:
 
 .. code-block:: yaml
 
@@ -14,6 +15,21 @@ it requires that the username and password to the joyent accound be configured
     JOYENT.password: saltybacon
     # The location of the ssh private key that can log into the new VM
     JOYENT.private_key: /root/joyent.pem
+
+
+Using the new format, set up the cloud configuration at
+ ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/ec2.conf``:
+
+.. code-block:: yaml
+
+    joyent-config:
+      # The Joyent login user
+      user: fred
+      # The Joyent user's password
+      password: saltybacon
+      # The location of the ssh private key that can log into the new VM
+      private_key: /root/joyent.pem
+      provider: joyent
 
 '''
 
@@ -27,6 +43,7 @@ from saltcloud.libcloudfuncs import *
 
 # Import saltcloud libs
 import saltcloud.utils
+import saltcloud.config as config
 from saltcloud.utils import namespaced_function
 
 # Get logging started
@@ -50,10 +67,24 @@ def __virtual__():
     '''
     Set up the libcloud functions and check for JOYENT configs
     '''
-    if 'JOYENT.user' in __opts__ and 'JOYENT.password' in __opts__:
-        log.debug('Loading Joyent cloud module')
-        return 'joyent'
-    return False
+    if get_configured_provider() is False:
+        log.info(
+            'There is no Joyent cloud provider configuration available. Not '
+            'loading module.'
+        )
+        return False
+
+    log.debug('Loading Joyent cloud module')
+    return 'joyent'
+
+
+def get_configured_provider():
+    '''
+    Return the first configured instance.
+    '''
+    return config.is_provider_configured(
+        __opts__, 'joyent', ('user', 'password')
+    )
 
 
 def get_conn():
@@ -62,9 +93,9 @@ def get_conn():
     '''
     driver = get_driver(Provider.JOYENT)
     return driver(
-            __opts__['JOYENT.user'],
-            __opts__['JOYENT.password'],
-            )
+        config.get_config_value('user', vm_, __opts__),
+        config.get_config_value('password', vm_, __opts__)
+    )
 
 
 def create(vm_):
@@ -74,35 +105,39 @@ def create(vm_):
     log.info('Creating Cloud VM {0}'.format(vm_['name']))
     saltcloud.utils.check_name(vm_['name'], 'a-zA-Z0-9-')
     conn = get_conn()
-    kwargs = {}
-    kwargs['name'] = vm_['name']
-    kwargs['image'] = get_image(conn, vm_)
-    kwargs['size'] = get_size(conn, vm_)
+    kwargs = {
+        'name': vm_['name'],
+        'image': get_image(conn, vm_),
+        'size': get_size(conn, vm_)
+    }
+
     try:
         data = conn.create_node(**kwargs)
     except Exception as exc:
-        err = ('Error creating {0} on JOYENT\n\n'
-               'The following exception was thrown by libcloud when trying to '
-               'run the initial deployment: \n{1}').format(
-                       vm_['name'], exc.message
-                       )
-        log.error(err)
+        log.error(
+            'Error creating {0} on JOYENT\n\n'
+            'The following exception was thrown by libcloud when trying to '
+            'run the initial deployment: \n{1}'.format(
+                vm_['name'], exc.message
+            )
+        )
+        log.debug(
+            'Error creating {0} on JOYENT\n\n'.format(
+                vm_['name']
+            ),
+            exc_info=True
+        )
         return False
 
-    deploy = vm_.get(
-        'deploy',
-        __opts__.get(
-            'JOYENT.deploy',
-            __opts__['deploy']
-        )
-    )
     ret = {}
-    if deploy is True:
+    if config.get_config_value('deploy', vm_, __opts__) is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
             'host': data.public_ips[0],
             'username': 'root',
-            'key_filename': __opts__['JOYENT.private_key'],
+            'key_filename': config.get_config_value(
+                'private_key', vm_, __opts__
+            ),
             'script': deploy_script.script,
             'name': vm_['name'],
             'deploy_command': '/tmp/deploy.sh',
@@ -113,10 +148,11 @@ def create(vm_):
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
             'keep_tmp': __opts__['keep_tmp'],
-            }
+        }
 
-        if 'script_args' in vm_:
-            deploy_kwargs['script_args'] = vm_['script_args']
+        deploy_kwargs['script_args'] = config.get_config_value(
+            'script_args', vm_, __opts__
+        )
 
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(
             __opts__,
@@ -124,7 +160,7 @@ def create(vm_):
         )
 
         # Deploy salt-master files, if necessary
-        if 'make_master' in vm_ and vm_['make_master'] is True:
+        if config.get_config_value('make_master', vm_, __opts__) is True:
             deploy_kwargs['make_master'] = True
             deploy_kwargs['master_pub'] = vm_['master_pub']
             deploy_kwargs['master_pem'] = vm_['master_pem']
@@ -165,7 +201,7 @@ def stop(name, call=None):
     data = {}
 
     if call != 'action':
-        print('This action must be called with -a or --action.')
+        log.error('This action must be called with -a or --action.')
         sys.exit(1)
 
     conn = get_conn()

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -199,8 +199,9 @@ def stop(name, call=None):
     data = {}
 
     if call != 'action':
-        log.error('This action must be called with -a or --action.')
-        sys.exit(1)
+        raise SaltCloudSystemExit(
+            'This action must be called with -a or --action.'
+        )
 
     conn = get_conn()
     node = get_node(conn, name)

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -22,7 +22,7 @@ Using the new format, set up the cloud configuration at
 
 .. code-block:: yaml
 
-    joyent-config:
+    my-joyent-config:
       # The Joyent login user
       user: fred
       # The Joyent user's password

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -53,6 +53,8 @@ log = logging.getLogger(__name__)
 # Some of the libcloud functions need to be in the same namespace as the
 # functions defined in the module, so we create new function objects inside
 # this module namespace
+get_size = namespaced_function(get_size, globals())
+get_image = namespaced_function(get_image, globals())
 avail_images = namespaced_function(avail_images, globals())
 avail_sizes = namespaced_function(avail_sizes, globals())
 script = namespaced_function(script, globals())

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -95,8 +95,18 @@ def get_conn():
     '''
     driver = get_driver(Provider.JOYENT)
     return driver(
-        config.get_config_value('user', vm_, __opts__, search_global=False),
-        config.get_config_value('password', vm_, __opts__, search_global=False)
+        config.get_config_value(
+            'user',
+            get_configured_provider(),
+            __opts__,
+            search_global=False
+        ),
+        config.get_config_value(
+            'password',
+            get_configured_provider(),
+            __opts__,
+            search_global=False
+        )
     )
 
 

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -18,7 +18,7 @@ Using the old cloud configuration syntax, it requires that the ``username`` and
 
 
 Using the new format, set up the cloud configuration at
- ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/ec2.conf``:
+ ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/joyent.conf``:
 
 .. code-block:: yaml
 

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -171,7 +171,8 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
-            ret['deploy_kwargs'] = deploy_kwargs
+            if __opts__.get('show_deploy_args', False) is True:
+                ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -409,7 +409,8 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {name}'.format(**vm_))
-            ret['deploy_kwargs'] = deploy_kwargs
+            if __opts__.get('show_deploy_args', False) is True:
+                ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error('Failed to start Salt on Cloud VM {name}'.format(**vm_))
 

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -206,10 +206,9 @@ def block_device_mappings(vm_):
     e.g. [{'DeviceName': '/dev/sdb', 'VirtualName': 'ephemeral0'},
           {'DeviceName': '/dev/sdc', 'VirtualName': 'ephemeral1'}]
     '''
-    block_device_mappings = vm_.get(
-        'block_device_mappings', __opts__.get('AWS.block_device_mappings', None)
+    return config.get_config_value(
+        'block_device_mappings', vm_, __opts__, search_global=False
     )
-    return block_device_mappings
 
 
 def ssh_username(vm_):

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -81,7 +81,7 @@ def __virtual__():
         pass
 
     if get_configured_provider() is False:
-        log.info(
+        log.debug(
             'There is no AWS cloud provider configuration available. Not '
             'loading module'
         )

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -111,7 +111,8 @@ def __virtual__():
             )
 
     global avail_images, avail_sizes, script, destroy, list_nodes
-    global list_nodes_full, list_nodes_select, get_image, get_size
+    global avail_locations, list_nodes_full, list_nodes_select, get_image
+    global get_size
 
     # open a connection in a specific region
     conn = get_conn(**{'location': get_location()})
@@ -119,6 +120,7 @@ def __virtual__():
     # Init the libcloud functions
     get_size = namespaced_function(get_size, globals(), (conn,))
     get_image = namespaced_function(get_image, globals(), (conn,))
+    avail_locations = namespaced_function(avail_locations, globals(), (conn,))
     avail_images = namespaced_function(avail_images, globals(), (conn,))
     avail_sizes = namespaced_function(avail_sizes, globals(), (conn,))
     script = namespaced_function(script, globals(), (conn,))

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -56,9 +56,7 @@ import saltcloud.utils
 import saltcloud.config as config
 from saltcloud.utils import namespaced_function
 from saltcloud.libcloudfuncs import *
-
-# Import salt libs
-from salt.exceptions import SaltException
+from saltcloud.exceptions import SaltCloudException, SaltCloudSystemExit
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -92,7 +90,7 @@ def __virtual__():
             continue
 
         if not os.path.exists(details['private_key']):
-            raise SaltException(
+            raise SaltCloudException(
                 'The AWS key file {0!r} used in the {1!r} provider '
                 'configuration does not exist\n'.format(
                     details['private_key'],
@@ -104,7 +102,7 @@ def __virtual__():
             oct(stat.S_IMODE(os.stat(details['private_key']).st_mode))
         )
         if keymode not in ('0400', '0600'):
-            raise SaltException(
+            raise SaltCloudException(
                 'The AWS key file {0!r} used in the {1!r} provider '
                 'configuration needs to be set to mode 0400 or 0600\n'.format(
                     details['private_key'],
@@ -167,7 +165,7 @@ def get_conn(**kwargs):
     if 'location' in kwargs:
         location = kwargs['location']
         if location not in EC2_LOCATIONS:
-            raise SaltException(
+            raise SaltCloudException(
                 'The specified location does not seem to be valid: '
                 '{0}\n'.format(
                     location
@@ -459,8 +457,9 @@ def stop(name, call=None):
     data = {}
 
     if call != 'action':
-        print('This action must be called with -a or --action.')
-        sys.exit(1)
+        raise SaltCloudSystemExit(
+            'This action must be called with -a or --action.'
+        )
 
     location = get_location()
     conn = get_conn(location=location)
@@ -482,8 +481,9 @@ def start(name, call=None):
     data = {}
 
     if call != 'action':
-        print('This action must be called with -a or --action.')
-        sys.exit(1)
+        raise SaltCloudSystemExit(
+            'This action must be called with -a or --action.'
+        )
 
     location = get_location()
     conn = get_conn(location=location)
@@ -507,8 +507,9 @@ def set_tags(name, tags, call=None):
         salt-cloud -a set_tags mymachine tag1=somestuff tag2='Other stuff'
     '''
     if call != 'action':
-        print('This action must be called with -a or --action.')
-        sys.exit(1)
+        raise SaltCloudSystemExit(
+            'This action must be called with -a or --action.'
+        )
 
     location = get_location()
     conn = get_conn(location=location)
@@ -532,8 +533,9 @@ def get_tags(name, call=None):
     data = {}
 
     if call != 'action':
-        print('This action must be called with -a or --action.')
-        sys.exit(1)
+        raise SaltCloudSystemExit(
+            'This action must be called with -a or --action.'
+        )
 
     location = get_location()
     conn = get_conn(location=location)
@@ -562,8 +564,9 @@ def del_tags(name, kwargs, call=None):
     ret = {}
 
     if call != 'action':
-        print('This action must be called with -a or --action.')
-        sys.exit(1)
+        raise SaltCloudSystemExit(
+            'This action must be called with -a or --action.'
+        )
 
     location = get_location()
     conn = get_conn(location=location)
@@ -596,8 +599,9 @@ def rename(name, kwargs, call=None):
         salt-cloud -a rename mymachine newname=yourmachine
     '''
     if call != 'action':
-        print('This action must be called with -a or --action.')
-        sys.exit(1)
+        raise SaltCloudSystemExit(
+            'This action must be called with -a or --action.'
+        )
 
     location = get_location()
     conn = get_conn(location=location)

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -39,6 +39,8 @@ Using the new format, set up the cloud configuration at
       # The location of the private key which corresponds to the keyname
       private_key: /root/default.pem
 
+      provider: aws
+
 '''
 
 # Import python libs

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -27,7 +27,7 @@ Using the new format, set up the cloud configuration at
 
 .. code-block:: yaml
 
-    aws-config:
+    my-aws-config:
       # The AWS API authentication id
       id: GKTADJGHEIQSXMKKRBJ08H
       # The AWS API authentication key

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -44,6 +44,8 @@ log = logging.getLogger(__name__)
 
 
 # Redirect linode functions to this module namespace
+get_size = namespaced_function(get_size, globals())
+get_image = namespaced_function(get_image, globals())
 avail_locations = namespaced_function(avail_locations, globals())
 avail_images = namespaced_function(avail_images, globals())
 avail_sizes = namespaced_function(avail_sizes, globals())

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -60,7 +60,7 @@ def __virtual__():
     Set up the libcloud functions and check for Linode configurations.
     '''
     if get_configured_provider() is False:
-        log.info(
+        log.debug(
             'There is no Linode cloud provider configuration available. Not '
             'loading module.'
         )

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -4,13 +4,25 @@ Linode Cloud Module
 
 The Linode cloud module is used to control access to the Linode VPS system
 
-Use of this module only requires the LINODE.apikey paramater to be set in
-the cloud configuration file
+Use of this module only requires the ``apikey`` parameter.
+If using the old cloud configuration syntax, add to salt cloud configuration
+file:
 
 .. code-block:: yaml
 
     # Linode account api key
     LINODE.apikey: JVkbSJDGHSDKUKSDJfhsdklfjgsjdkflhjlsdfffhgdgjkenrtuinv
+
+
+Using the new format, set up the cloud configuration at
+ ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/linode.conf``:
+
+.. code-block:: yaml
+
+    linode-config:
+      # Linode account api key
+      apikey: JVkbSJDGHSDKUKSDJfhsdklfjgsjdkflhjlsdfffhgdgjkenrtuinv
+      provider: linode
 
 '''
 
@@ -19,13 +31,11 @@ import sys
 import logging
 
 # Import libcloud
-from libcloud.compute.types import NodeState
 from libcloud.compute.base import NodeAuthPassword
 
-# Import salt libs
+# Import salt cloud libs
+import saltcloud.config as config
 from saltcloud.libcloudfuncs import *
-
-# Import saltcloud libs
 from saltcloud.utils import namespaced_function
 
 
@@ -47,12 +57,24 @@ list_nodes_select = namespaced_function(list_nodes_select, globals())
 # Only load in this module if the LINODE configurations are in place
 def __virtual__():
     '''
-    Set up the libcloud funcstions and check for RACKSPACE configs
+    Set up the libcloud functions and check for Linode configurations.
     '''
-    if 'LINODE.apikey' in __opts__:
-        log.debug('Loading Linode cloud module')
-        return 'linode'
+    if get_configured_provider() is False:
+        log.info(
+            'There is no Linode cloud provider configuration available. Not '
+            'loading module.'
+        )
+        return False
+
+    log.debug('Loading Linode cloud module')
     return False
+
+
+def get_configured_provider():
+    '''
+    Return the first configured instance.
+    '''
+    return config.is_provider_configured(__opts__, 'linode', ('apikey',))
 
 
 def get_conn():
@@ -61,8 +83,8 @@ def get_conn():
     '''
     driver = get_driver(Provider.LINODE)
     return driver(
-            __opts__['LINODE.apikey'],
-            )
+        config.get_config_value('apikey', vm_, __opts__)
+    )
 
 
 def get_location(conn, vm_):
@@ -71,15 +93,9 @@ def get_location(conn, vm_):
     '''
     locations = conn.list_locations()
     # Default to Dallas if not otherwise set
-    loc = 2
-    if 'location' in vm_:
-        loc = vm_['location']
-    elif 'LINODE.location' in __opts__:
-        loc = __opts__['LINODE.location']
+    loc = config.get_config_value('location', vm_, __opts__, default=2)
     for location in locations:
-        if str(location.id) == str(loc):
-            return location
-        if location.name == loc:
+        if str(loc) in (str(location.id), str(location.name)):
             return location
 
 
@@ -87,12 +103,11 @@ def get_password(vm_):
     '''
     Return the password to use
     '''
-    if 'password' in vm_:
-        return vm_['password']
-    elif 'passwd' in vm_:
-        return vm_['passwd']
-    elif 'LINODE.password' in __opts__:
-        return __opts__['LINODE.password']
+    return config.get_config_value(
+        'password', vm_, __opts__, default=config.get_config_value(
+            'passwd', vm_, __opts__
+        )
+    )
 
 
 def create(vm_):
@@ -101,38 +116,36 @@ def create(vm_):
     '''
     log.info('Creating Cloud VM {0}'.format(vm_['name']))
     conn = get_conn()
-    kwargs = {}
-    kwargs['name'] = vm_['name']
-    kwargs['image'] = get_image(conn, vm_)
-    kwargs['size'] = get_size(conn, vm_)
-    kwargs['location'] = get_location(conn, vm_)
-    kwargs['auth'] = NodeAuthPassword(get_password(vm_))
+    kwargs = {
+        'name': vm_['name'],
+        'image': get_image(conn, vm_),
+        'size': get_size(conn, vm_),
+        'location': get_location(conn, vm_),
+        'auth': NodeAuthPassword(get_password(vm_))
+    }
     try:
         data = conn.create_node(**kwargs)
     except Exception as exc:
-        err = ('Error creating {0} on LINODE\n\n'
-               'The following exception was thrown by libcloud when trying to '
-               'run the initial deployment: \n{1}').format(
-                       vm_['name'], exc.message
-                       )
-        sys.stderr.write(err)
-        log.error(err)
+        log.error(
+            'Error creating {0} on LINODE\n\n'
+            'The following exception was thrown by libcloud when trying to '
+            'run the initial deployment: \n{1}'.format(
+                vm_['name'], exc.message
+            )
+        )
+        log.debug(
+            'Error creating {0} on LINODE\n\n'.format(vm_['name']),
+            exc_info=True
+        )
         return False
 
-    deploy = vm_.get(
-        'deploy',
-        __opts__.get(
-            'LINODE.deploy',
-            __opts__['deploy']
-        )
-    )
     ret = {}
-    if deploy is True:
+    if config.get_config_value('deploy', vm_, __opts__) is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
             'host': data.public_ips[0],
             'username': 'root',
-            'password': __opts__['LINODE.password'],
+            'password': get_password(vm_),
             'script': deploy_script.script,
             'name': vm_['name'],
             'deploy_command': '/tmp/deploy.sh',
@@ -141,11 +154,12 @@ def create(vm_):
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
-            'keep_tmp': __opts__['keep_tmp'],
-            }
+            'keep_tmp': __opts__['keep_tmp']
+        }
 
-        if 'script_args' in vm_:
-            deploy_kwargs['script_args'] = vm_['script_args']
+        deploy_kwargs['script_args'] = config.get_config_value(
+            'script_args', vm_, __opts__
+        )
 
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(
             __opts__,
@@ -153,7 +167,7 @@ def create(vm_):
         )
 
         # Deploy salt-master files, if necessary
-        if 'make_master' in vm_ and vm_['make_master'] is True:
+        if config.get_config_value('make_master', vm_, __opts__) is True:
             deploy_kwargs['make_master'] = True
             deploy_kwargs['master_pub'] = vm_['master_pub']
             deploy_kwargs['master_pem'] = vm_['master_pem']

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -19,7 +19,7 @@ Using the new format, set up the cloud configuration at
 
 .. code-block:: yaml
 
-    linode-config:
+    my-linode-config:
       # Linode account api key
       apikey: JVkbSJDGHSDKUKSDJfhsdklfjgsjdkflhjlsdfffhgdgjkenrtuinv
       provider: linode

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -180,7 +180,8 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
-            ret['deploy_kwargs'] = deploy_kwargs
+            if __opts__.get('show_deploy_args', False) is True:
+                ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -83,7 +83,7 @@ def get_conn():
     '''
     driver = get_driver(Provider.LINODE)
     return driver(
-        config.get_config_value('apikey', vm_, __opts__)
+        config.get_config_value('apikey', vm_, __opts__, search_global=False)
     )
 
 
@@ -105,8 +105,8 @@ def get_password(vm_):
     '''
     return config.get_config_value(
         'password', vm_, __opts__, default=config.get_config_value(
-            'passwd', vm_, __opts__
-        )
+            'passwd', vm_, __opts__, search_global=False
+        ), search_global=False
     )
 
 
@@ -131,11 +131,9 @@ def create(vm_):
             'The following exception was thrown by libcloud when trying to '
             'run the initial deployment: \n{1}'.format(
                 vm_['name'], exc.message
-            )
-        )
-        log.debug(
-            'Error creating {0} on LINODE\n\n'.format(vm_['name']),
-            exc_info=True
+            ),
+            # Show the traceback if the debug logging level is enabled
+            exc_info=log.isEnabledFor(logging.DEBUG)
         )
         return False
 
@@ -154,12 +152,11 @@ def create(vm_):
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
-            'keep_tmp': __opts__['keep_tmp']
+            'keep_tmp': __opts__['keep_tmp'],
+            'script_args': config.get_config_value(
+                'script_args', vm_, __opts__
+            )
         }
-
-        deploy_kwargs['script_args'] = config.get_config_value(
-            'script_args', vm_, __opts__
-        )
 
         deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(
             __opts__,

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -85,7 +85,9 @@ def get_conn():
     '''
     driver = get_driver(Provider.LINODE)
     return driver(
-        config.get_config_value('apikey', vm_, __opts__, search_global=False)
+        config.get_config_value(
+            'apikey', get_configured_provider(), __opts__, search_global=False
+        )
     )
 
 

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -397,13 +397,13 @@ def create(vm_):
         vm_
     )
 
-    ssh_username = config.get_config_value('ssh_username', vm_, __opts__)
-    if ssh_username is not None:
+    ssh_username = config.get_config_value(
+        'ssh_username', vm_, __opts__, default='root'
+    )
+    if ssh_username != 'root':
         deploy_kwargs['deploy_command'] = '/tmp/deploy.sh'
         deploy_kwargs['username'] = ssh_username
         deploy_kwargs['tty'] = True
-    else:
-        deploy_kwargs['username'] = 'root'
 
     log.debug('Using {0} as SSH username'.format(ssh_username))
 
@@ -446,7 +446,8 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
-            ret['deploy_kwargs'] = deploy_kwargs
+            if __opts__.get('show_deploy_args', False) is True:
+                ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -110,7 +110,11 @@ from saltcloud.libcloudfuncs import *
 # Import saltcloud libs
 import saltcloud.config as config
 from saltcloud.utils import namespaced_function
-from saltcloud.exceptions import SaltCloudException, SaltCloudSystemExit
+from saltcloud.exceptions import (
+    SaltCloudNotFound,
+    SaltCloudException,
+    SaltCloudSystemExit,
+)
 
 # Import netaddr IP matching
 try:
@@ -304,7 +308,7 @@ def create(vm_):
             if vg in [ag.name for ag in avail_groups]:
                 group_list.append(vg)
             else:
-                raise ValueError(
+                raise SaltCloudNotFound(
                     'No such security group: \'{0}\''.format(
                         group
                     )

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -143,7 +143,7 @@ def __virtual__():
     Set up the libcloud functions and check for OPENSTACK configurations
     '''
     if get_configured_provider() is False:
-        log.info(
+        log.debug(
             'There is no Openstack cloud provider configuration available. '
             'Not loading module.'
         )

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -171,19 +171,34 @@ def get_conn():
     driver = get_driver(Provider.OPENSTACK)
     authinfo = {
         'ex_force_auth_url': config.get_config_value(
-            'identity_url', vm_, __opts__, search_global=False
+            'identity_url',
+            get_configured_provider(),
+            __opts__,
+            search_global=False
         ),
         'ex_force_service_name': config.get_config_value(
-            'compute_name', vm_, __opts__, search_global=False
+            'compute_name',
+            get_configured_provider(),
+            __opts__,
+            search_global=False
         ),
         'ex_force_service_region': config.get_config_value(
-            'compute_region', vm_, __opts__, search_global=False
+            'compute_region',
+            get_configured_provider(),
+            __opts__,
+            search_global=False
         ),
         'ex_tenant_name': config.get_config_value(
-            'tenant', vm_, __opts__, search_global=False
+            'tenant',
+            get_configured_provider(),
+            __opts__,
+            search_global=False
         ),
         'ex_force_service_name': config.get_config_value(
-            'compute_name', vm_, __opts__, search_global=False
+            'compute_name',
+            get_configured_provider(),
+            __opts__,
+            search_global=False
         )
     }
 

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -128,6 +128,8 @@ log = logging.getLogger(__name__)
 # Some of the libcloud functions need to be in the same namespace as the
 # functions defined in the module, so we create new function objects inside
 # this module namespace
+get_size = namespaced_function(get_size, globals())
+get_image = namespaced_function(get_image, globals())
 avail_images = namespaced_function(avail_images, globals())
 avail_sizes = namespaced_function(avail_sizes, globals())
 script = namespaced_function(script, globals())

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -107,12 +107,10 @@ from libcloud.compute.base import NodeState
 # Import generic libcloud functions
 from saltcloud.libcloudfuncs import *
 
-# Import salt libs
-from salt.exceptions import SaltException
-
 # Import saltcloud libs
 import saltcloud.config as config
 from saltcloud.utils import namespaced_function
+from saltcloud.exceptions import SaltCloudException, SaltCloudSystemExit
 
 # Import netaddr IP matching
 try:
@@ -377,7 +375,7 @@ def create(vm_):
     log.debug('Using IP address {0}'.format(ip_address))
 
     if not ip_address:
-        raise SaltException('A valid IP address was not found')
+        raise SaltCloudException('A valid IP address was not found')
 
     deploy_kwargs = {
         'host': ip_address,

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -48,7 +48,7 @@ configuration at ``/etc/salt/cloud.providers`` or
 
 .. code-block:: yaml
 
-    openstack-config:
+    my-openstack-config:
       # The OpenStack identity service url
       identity_url: https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/
       # The OpenStack compute region
@@ -68,7 +68,7 @@ Either a password or an API key must also be specified:
 
 .. code-block:: yaml
 
-    openstack-password-or-api-config:
+    my-openstack-password-or-api-config:
       # The OpenStack password
       password: letmein
       # The OpenStack API key
@@ -88,7 +88,7 @@ Using the new syntax:
 
 .. code-block:: yaml
 
-    openstack-config:
+    my-openstack-config:
       # Ignore IP addresses on this network for bootstrap
       ignore_ip_addr: 192.168.50.0/24
 

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -168,37 +168,23 @@ def get_conn():
     '''
     Return a conn object for the passed VM data
     '''
+    vm_ = get_configured_provider()
     driver = get_driver(Provider.OPENSTACK)
     authinfo = {
         'ex_force_auth_url': config.get_config_value(
-            'identity_url',
-            get_configured_provider(),
-            __opts__,
-            search_global=False
+            'identity_url', vm_, __opts__, search_global=False
         ),
         'ex_force_service_name': config.get_config_value(
-            'compute_name',
-            get_configured_provider(),
-            __opts__,
-            search_global=False
+            'compute_name', vm_, __opts__, search_global=False
         ),
         'ex_force_service_region': config.get_config_value(
-            'compute_region',
-            get_configured_provider(),
-            __opts__,
-            search_global=False
+            'compute_region', vm_, __opts__, search_global=False
         ),
         'ex_tenant_name': config.get_config_value(
-            'tenant',
-            get_configured_provider(),
-            __opts__,
-            search_global=False
+            'tenant', vm_, __opts__, search_global=False
         ),
         'ex_force_service_name': config.get_config_value(
-            'compute_name',
-            get_configured_provider(),
-            __opts__,
-            search_global=False
+            'compute_name', vm_, __opts__, search_global=False
         )
     }
 

--- a/saltcloud/clouds/parallels.py
+++ b/saltcloud/clouds/parallels.py
@@ -5,8 +5,8 @@ Parallels Cloud Module
 The Parallels cloud module is used to control access to cloud providers using
 the Parallels VPS system.
 
-Use of this module requires the following PARALLELS paramaters to be set in the
-cloud configuration file.
+Use of this module requires, if using the old salt cloud configuration syntax,
+the following PARALLELS parameters to be set in the cloud configuration file.
 
 .. code-block:: yaml
 
@@ -15,14 +15,26 @@ cloud configuration file.
     PARALLELS.password: mypassword
     PARALLELS.url: https://api.cloud.xmission.com:4465/paci/v1.0/
 
+
+Using the new format, set up the cloud configuration at
+ ``/etc/salt/cloud.providers`` or
+ ``/etc/salt/cloud.providers.d/parallels.conf``:
+
+
+.. code-block:: yaml
+
+    parallels-config:
+      # Parallels account information
+      user: myuser
+      password: mypassword
+      url: https://api.cloud.xmission.com:4465/paci/v1.0/
+      provider: parallels
+
 '''
 
 # Import python libs
-import re
 import sys
 import time
-import yaml
-import json
 import urllib
 import urllib2
 import logging
@@ -31,7 +43,10 @@ import xml.etree.ElementTree as ET
 # Import salt libs
 import salt.utils.event
 import salt.utils.xmlutil
+
+# Import salt cloud libs
 import saltcloud.utils
+import saltcloud.config as config
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -40,12 +55,24 @@ log = logging.getLogger(__name__)
 # Only load in this module if the PARALLELS configurations are in place
 def __virtual__():
     '''
-    Check for PARALLELS configs
+    Check for PARALLELS configurations
     '''
-    if 'PARALLELS.user' in __opts__:
-        log.debug('Loading Parallels cloud module')
-        return 'parallels'
-    return False
+    if get_configured_provider() is False:
+        log.info(
+            'There is no Parallels cloud provider configuration available. '
+            'Not loading module.'
+        )
+        return False
+
+    log.debug('Loading Parallels cloud module')
+    return 'parallels'
+
+
+def get_configured_provider():
+    '''
+    Return the first configured instance.
+    '''
+    return config.is_provider_configured(__opts__, 'parallels', ('user',))
 
 
 def avail_locations():
@@ -53,11 +80,12 @@ def avail_locations():
     Return a dict of all available VM locations on the cloud provider with
     relevant data
     '''
-    return {'Error':
-               {'Not Supported':
-                   '--list-locations not currently supported by Parallels'
-               }
-           }
+    return {
+        'Error': {
+            'Not Supported': '--list-locations not currently supported by '
+                             'Parallels'
+        }
+    }
 
 
 def avail_images():
@@ -76,11 +104,12 @@ def avail_sizes():
     '''
     Return a list of the image sizes that are on the provider
     '''
-    return {'Error':
-               {'Not Supported':
-                   '--list-sizes not currently supported by Parallels'
-               }
-           }
+    return {
+        'Error': {
+            'Not Supported': '--list-sizes not currently supported by '
+                             'Parallels'
+        }
+    }
 
 
 def list_nodes():
@@ -121,9 +150,13 @@ def list_nodes_full():
         ret[name] = node
         ret[name]['image'] = node['platform']['template-info']['name']
         if 'private-ip' in node['network']:
-            ret[name]['private_ips'] = [node['network']['private-ip']['address']]
+            ret[name]['private_ips'] = [
+                node['network']['private-ip']['address']
+            ]
         if 'public-ip' in node['network']:
-            ret[name]['public_ips'] = [node['network']['public-ip']['address']]
+            ret[name]['public_ips'] = [
+                node['network']['public-ip']['address']
+            ]
 
     return ret
 
@@ -152,12 +185,11 @@ def get_image(vm_):
     Return the image object to use
     '''
     images = avail_images()
+    vm_image = config.get_config_value('image', vm_, __opts__)
     for image in images:
-        if images[image]['name'] == str(vm_['image']):
+        if str(vm_image) in (images[image]['name'], images[image]['id']):
             return images[image]['id']
-        if images[image]['id'] == str(vm_['image']):
-            return images[image]['id']
-    raise ValueError("The specified image could not be found.")
+    raise ValueError('The specified image could not be found.')
 
 
 def create_node(vm_):
@@ -186,36 +218,45 @@ def create_node(vm_):
 
     # Bandwidth available, in kbps
     bandwidth = ET.SubElement(content, 'bandwidth')
-    bandwidth.text = vm_.get('bandwidth', '100')
+    bandwidth.text = config.get_config_value(
+        'bandwidth', vm_, __opts__, default='100'
+    )
 
     # How many public IPs will be assigned to this instance
     ip_num = ET.SubElement(content, 'no-of-public-ip')
-    ip_num.text = vm_.get('ip_num', '1')
+    ip_num.text = config.get_config_value(
+        'ip_num', vm_, __opts__, default='1'
+    )
 
     # Size of the instance disk
     disk = ET.SubElement(content, 've-disk')
     disk.attrib['local'] = 'true'
-    disk.attrib['size'] = vm_.get('disk_size', '10')
+    disk.attrib['size'] = config.get_config_value(
+        'disk_size', vm_, __opts__, default='10'
+    )
 
     # Attributes for the image
-    image = show_image({'image': vm_['image']}, call='function')
+    vm_image = config.get_config_value('image', vm_, __opts__)
+    image = show_image({'image': vm_image}, call='function')
     platform = ET.SubElement(content, 'platform')
     template = ET.SubElement(platform, 'template-info')
-    template.attrib['name'] = vm_['image']
+    template.attrib['name'] = vm_image
     os = ET.SubElement(platform, 'os-info')
-    os.attrib['technology'] = image[vm_['image']]['technology']
-    os.attrib['type'] = image[vm_['image']]['osType']
+    os.attrib['technology'] = image[vm_image]['technology']
+    os.attrib['type'] = image[vm_image]['osType']
 
     # Username and password
     admin = ET.SubElement(content, 'admin')
-    admin.attrib['login'] = vm_.get('ssh_username', 'root')
-    admin.attrib['password'] = __opts__['PARALLELS.password']
+    admin.attrib['login'] = config.get_config_value(
+        'ssh_username', vm_, __opts__, default='root'
+    )
+    admin.attrib['password'] = config.get_config_value(
+        'password', vm_, __opts__
+    )
 
     data = ET.tostring(content, encoding='UTF-8')
 
-    node = query(action='ve',
-                 method='POST',
-                 data=data)
+    node = query(action='ve', method='POST', data=data)
     return node
 
 
@@ -224,18 +265,19 @@ def create(vm_):
     Create a single VM from a data dict
     '''
     log.info('Creating Cloud VM {0}'.format(vm_['name']))
-    deploy_script = script(vm_)
 
     try:
         data = create_node(vm_)
     except Exception as exc:
-        err = ('Error creating {0} on PARALLELS\n\n'
-               'The following exception was thrown when trying to '
-               'run the initial deployment: \n{1}').format(
-                       vm_['name'], exc.message
-                       )
-        sys.stderr.write(err)
-        log.error(err)
+        log.error(
+            'Error creating {0} on PARALLELS\n\n'
+            'The following exception was thrown when trying to '
+            'run the initial deployment: \n{1}'.format(
+                vm_['name'], exc.message
+            ),
+            # Show the traceback if the debug logging level is enabled
+            exc_info=log.isEnabledFor(logging.DEBUG)
+        )
         return False
 
     name = vm_['name']
@@ -258,12 +300,12 @@ def create(vm_):
     comps = data['network']['public-ip']['address'].split('/')
     public_ip = comps[0]
 
-    if __opts__['deploy'] is True:
+    if config.get_config_value('deploy', vm_, __opts__) is True:
         deploy_script = script(vm_)
         deploy_kwargs = {
             'host': public_ip,
             'username': 'root',
-            'password': __opts__['PARALLELS.password'],
+            'password': config.get_config_value('password', vm_, __opts__),
             'script': deploy_script,
             'name': vm_['name'],
             'deploy_command': '/tmp/deploy.sh',
@@ -273,20 +315,30 @@ def create(vm_):
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
             'keep_tmp': __opts__['keep_tmp'],
-            }
+            'script_args': config.get_config_value(
+                'script_args', vm_, __opts__
+            )
+        }
 
-        if 'script_args' in vm_:
-            deploy_kwargs['script_args'] = vm_['script_args']
-
-        deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
+        deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(
+            __opts__, vm_
+        )
 
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
         else:
-            log.error('Failed to start Salt on Cloud VM {0}'.format(vm_['name']))
+            log.error(
+                'Failed to start Salt on Cloud VM {0}'.format(
+                    vm_['name']
+                )
+            )
 
-    log.info('Created Cloud VM {0} with the following values:'.format(vm_['name']))
+    log.info(
+        'Created Cloud VM {0} with the following values:'.format(
+            vm_['name']
+        )
+    )
 
     return data
 
@@ -295,12 +347,20 @@ def query(action=None, command=None, args=None, method='GET', data=None):
     '''
     Make a web call to a Parallels provider
     '''
-    path = __opts__['PARALLELS.url']
+    path = config.get_config_value(
+        'url', get_configured_provider(), __opts__
+    )
     auth_handler = urllib2.HTTPBasicAuthHandler()
-    auth_handler.add_password(realm='Parallels Instance Manager',
-                              uri=path,
-                              user=__opts__['PARALLELS.user'],
-                              passwd=__opts__['PARALLELS.password'])
+    auth_handler.add_password(
+        realm='Parallels Instance Manager',
+        uri=path,
+        user=config.get_config_value(
+            'user', get_configured_provider(), __opts__
+        ),
+        passwd=config.get_config_value(
+           'password', get_configured_provider(), __opts__
+        )
+    )
     opener = urllib2.build_opener(auth_handler)
     urllib2.install_opener(opener)
 
@@ -334,18 +394,26 @@ def query(action=None, command=None, args=None, method='GET', data=None):
 
     try:
         result = urllib2.urlopen(req)
-        log.debug('PARALLELS Response Status Code: {0}'.format(result.getcode()))
+        log.debug(
+            'PARALLELS Response Status Code: {0}'.format(
+                result.getcode()
+            )
+        )
 
         if 'content-length' in result.headers:
             content = result.read()
             result.close()
             items = ET.fromstring(content)
             return items
-        else:
-            return {}
+
+        return {}
     except urllib2.URLError as exc:
-        log.error('PARALLELS Response Status Code: {0} {1}'.format(exc.code,
-                                                             exc.msg))
+        log.error(
+            'PARALLELS Response Status Code: {0} {1}'.format(
+                exc.code,
+                exc.msg
+            )
+        )
         root = ET.fromstring(exc.read())
         log.error(_xml_to_dict(root))
         return {'error': _xml_to_dict(root)}
@@ -357,14 +425,8 @@ def script(vm_):
     '''
     minion = saltcloud.utils.minion_conf_string(__opts__, vm_)
     script = saltcloud.utils.os_script(
-        saltcloud.utils.get_option(
-            'script',
-            __opts__,
-            vm_
-        ),
-        vm_,
-        __opts__,
-        minion,
+        config.get_config_value('script', vm_, __opts__),
+        vm_, __opts__, minion
     )
     return script
 
@@ -437,7 +499,11 @@ def destroy(name, call=None):
     if node['state'] == 'STARTED':
         stop(name, call='action')
         if not wait_until(name, 'STOPPED'):
-            return {'Error': 'Unable to destroy {0}, command timed out'.format(name)}
+            return {
+                'Error': 'Unable to destroy {0}, command timed out'.format(
+                    name
+                )
+            }
 
     data = query(action='ve', command=name, method='DELETE')
 

--- a/saltcloud/clouds/parallels.py
+++ b/saltcloud/clouds/parallels.py
@@ -324,6 +324,18 @@ def create(vm_):
             __opts__, vm_
         )
 
+        # Deploy salt-master files, if necessary
+        if config.get_config_value('make_master', vm_, __opts__) is True:
+            deploy_kwargs['make_master'] = True
+            deploy_kwargs['master_pub'] = vm_['master_pub']
+            deploy_kwargs['master_pem'] = vm_['master_pem']
+            master_conf = saltcloud.utils.master_conf_string(__opts__, vm_)
+            if master_conf:
+                deploy_kwargs['master_conf'] = master_conf
+
+            if 'syndic_master' in master_conf:
+                deploy_kwargs['make_syndic'] = True
+
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))

--- a/saltcloud/clouds/parallels.py
+++ b/saltcloud/clouds/parallels.py
@@ -42,7 +42,7 @@ import xml.etree.ElementTree as ET
 # Import salt cloud libs
 import saltcloud.utils
 import saltcloud.config as config
-from saltcloud.exceptions import SaltCloudSystemExit
+from saltcloud.exceptions import SaltCloudNotFound, SaltCloudSystemExit
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -187,7 +187,7 @@ def get_image(vm_):
     for image in images:
         if str(vm_image) in (images[image]['name'], images[image]['id']):
             return images[image]['id']
-    raise ValueError('The specified image could not be found.')
+    raise SaltCloudNotFound('The specified image could not be found.')
 
 
 def create_node(vm_):

--- a/saltcloud/clouds/parallels.py
+++ b/saltcloud/clouds/parallels.py
@@ -353,6 +353,8 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
+            if __opts__.get('show_deploy_args', False) is True:
+                ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(

--- a/saltcloud/clouds/parallels.py
+++ b/saltcloud/clouds/parallels.py
@@ -58,7 +58,7 @@ def __virtual__():
     Check for PARALLELS configurations
     '''
     if get_configured_provider() is False:
-        log.info(
+        log.debug(
             'There is no Parallels cloud provider configuration available. '
             'Not loading module.'
         )

--- a/saltcloud/clouds/parallels.py
+++ b/saltcloud/clouds/parallels.py
@@ -33,20 +33,16 @@ Using the new format, set up the cloud configuration at
 '''
 
 # Import python libs
-import sys
 import time
 import urllib
 import urllib2
 import logging
 import xml.etree.ElementTree as ET
 
-# Import salt libs
-import salt.utils.event
-import salt.utils.xmlutil
-
 # Import salt cloud libs
 import saltcloud.utils
 import saltcloud.config as config
+from saltcloud.exceptions import SaltCloudSystemExit
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -465,10 +461,9 @@ def show_image(kwargs, call=None):
     Show the details from Parallels concerning an image
     '''
     if call != 'function':
-        log.error(
+        raise SaltCloudSystemExit(
             'The show_image function must be called with -f or --function.'
         )
-        sys.exit(1)
 
     items = query(action='template', command=kwargs['image'])
     return {items.attrib['name']: items.attrib}
@@ -479,10 +474,9 @@ def show_instance(name, call=None):
     Show the details from Parallels concerning an instance
     '''
     if call != 'action':
-        log.error(
+        raise SaltCloudSystemExit(
             'The show_instance action must be called with -a or --action.'
         )
-        sys.exit(1)
 
     items = query(action='ve', command=name)
 
@@ -551,10 +545,9 @@ def start(name, call=None):
         salt-cloud -a start mymachine
     '''
     if call != 'action':
-        log.error(
+        raise SaltCloudSystemExit(
             'The show_instance action must be called with -a or --action.'
         )
-        sys.exit(1)
 
     data = query(action='ve', command='{0}/start'.format(name), method='PUT')
 
@@ -573,10 +566,9 @@ def stop(name, call=None):
         salt-cloud -a stop mymachine
     '''
     if call != 'action':
-        log.error(
+        raise SaltCloudSystemExit(
             'The show_instance action must be called with -a or --action.'
         )
-        sys.exit(1)
 
     data = query(action='ve', command='{0}/stop'.format(name), method='PUT')
 

--- a/saltcloud/clouds/parallels.py
+++ b/saltcloud/clouds/parallels.py
@@ -185,7 +185,9 @@ def get_image(vm_):
     Return the image object to use
     '''
     images = avail_images()
-    vm_image = config.get_config_value('image', vm_, __opts__)
+    vm_image = config.get_config_value(
+        'image', vm_, __opts__, search_global=False
+    )
     for image in images:
         if str(vm_image) in (images[image]['name'], images[image]['id']):
             return images[image]['id']
@@ -205,38 +207,48 @@ def create_node(vm_):
 
     # Description, defaults to name
     desc = ET.SubElement(content, 'description')
-    desc.text = vm_.get('desc', vm_['name'])
+    desc.text = config.get_config_value(
+        'desc', vm_, __opts__, default=vm_['name'], search_global=False
+    )
 
     # How many CPU cores, and how fast they are
     cpu = ET.SubElement(content, 'cpu')
-    cpu.attrib['number'] = vm_.get('cpu_number', '1')
-    cpu.attrib['power'] = vm_.get('cpu_power', '1000')
+    cpu.attrib['number'] = config.get_config_value(
+        'cpu_number', vm_, __opts__, default='1', search_global=False
+    )
+    cpu.attrib['power'] = config.get_config_value(
+        'cpu_power', vm_, __opts__, default='1000', search_global=False
+    )
 
     # How many megabytes of RAM
     ram = ET.SubElement(content, 'ram-size')
-    ram.text = vm_.get('ram', '256')
+    ram.text = config.get_config_value(
+        'ram', vm_, __opts__, default='256', search_global=False
+    )
 
     # Bandwidth available, in kbps
     bandwidth = ET.SubElement(content, 'bandwidth')
     bandwidth.text = config.get_config_value(
-        'bandwidth', vm_, __opts__, default='100'
+        'bandwidth', vm_, __opts__, default='100', search_global=False
     )
 
     # How many public IPs will be assigned to this instance
     ip_num = ET.SubElement(content, 'no-of-public-ip')
     ip_num.text = config.get_config_value(
-        'ip_num', vm_, __opts__, default='1'
+        'ip_num', vm_, __opts__, default='1', search_global=False
     )
 
     # Size of the instance disk
     disk = ET.SubElement(content, 've-disk')
     disk.attrib['local'] = 'true'
     disk.attrib['size'] = config.get_config_value(
-        'disk_size', vm_, __opts__, default='10'
+        'disk_size', vm_, __opts__, default='10', search_global=False
     )
 
     # Attributes for the image
-    vm_image = config.get_config_value('image', vm_, __opts__)
+    vm_image = config.get_config_value(
+        'image', vm_, __opts__, search_global=False
+    )
     image = show_image({'image': vm_image}, call='function')
     platform = ET.SubElement(content, 'platform')
     template = ET.SubElement(platform, 'template-info')
@@ -251,7 +263,7 @@ def create_node(vm_):
         'ssh_username', vm_, __opts__, default='root'
     )
     admin.attrib['password'] = config.get_config_value(
-        'password', vm_, __opts__
+        'password', vm_, __opts__, search_global=False
     )
 
     data = ET.tostring(content, encoding='UTF-8')
@@ -305,7 +317,9 @@ def create(vm_):
         deploy_kwargs = {
             'host': public_ip,
             'username': 'root',
-            'password': config.get_config_value('password', vm_, __opts__),
+            'password': config.get_config_value(
+                'password', vm_, __opts__, search_global=False
+            ),
             'script': deploy_script,
             'name': vm_['name'],
             'deploy_command': '/tmp/deploy.sh',
@@ -360,17 +374,18 @@ def query(action=None, command=None, args=None, method='GET', data=None):
     Make a web call to a Parallels provider
     '''
     path = config.get_config_value(
-        'url', get_configured_provider(), __opts__
+        'url', get_configured_provider(), __opts__, search_global=False
     )
     auth_handler = urllib2.HTTPBasicAuthHandler()
     auth_handler.add_password(
         realm='Parallels Instance Manager',
         uri=path,
         user=config.get_config_value(
-            'user', get_configured_provider(), __opts__
+            'user', get_configured_provider(), __opts__, search_global=False
         ),
         passwd=config.get_config_value(
-           'password', get_configured_provider(), __opts__
+            'password', get_configured_provider(), __opts__,
+            search_global=False
         )
     )
     opener = urllib2.build_opener(auth_handler)

--- a/saltcloud/clouds/parallels.py
+++ b/saltcloud/clouds/parallels.py
@@ -23,7 +23,7 @@ Using the new format, set up the cloud configuration at
 
 .. code-block:: yaml
 
-    parallels-config:
+    my-parallels-config:
       # Parallels account information
       user: myuser
       password: mypassword

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -26,7 +26,7 @@ Using the new format, set up the cloud configuration at
 
 .. code-block:: yaml
 
-    rackspace-config:
+    my-rackspace-config:
       # The Rackspace login user
       user: fred
       # The Rackspace user's apikey

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -62,6 +62,8 @@ log = logging.getLogger(__name__)
 # Some of the libcloud functions need to be in the same namespace as the
 # functions defined in the module, so we create new function objects inside
 # this module namespace
+get_size = namespaced_function(get_size, globals())
+get_image = namespaced_function(get_image, globals())
 avail_images = namespaced_function(avail_images, globals())
 avail_sizes = namespaced_function(avail_sizes, globals())
 script = namespaced_function(script, globals())

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -102,8 +102,8 @@ def get_conn():
     '''
     driver = get_driver(Provider.RACKSPACE)
     return driver(
-        config.get_config_value('user', vm_, __opts__),
-        config.get_config_value('apikey', vm_, __opts__)
+        config.get_config_value('user', vm_, __opts__, search_global=False),
+        config.get_config_value('apikey', vm_, __opts__, search_global=False)
     )
 
 
@@ -111,7 +111,9 @@ def preferred_ip(vm_, ips):
     '''
     Return the preferred Internet protocol. Either 'ipv4' (default) or 'ipv6'.
     '''
-    proto = config.get_config_value('protocol', vm_, __opts__, default='ipv4')
+    proto = config.get_config_value(
+        'protocol', vm_, __opts__, default='ipv4', search_global=False
+    )
     family = socket.AF_INET
     if proto == 'ipv6':
         family = socket.AF_INET6
@@ -130,7 +132,8 @@ def ssh_interface(vm_):
     or 'private_ips'.
     '''
     return config.get_config_value(
-        'ssh_interface', vm_, __opts__, default='public_ips'
+        'ssh_interface', vm_, __opts__, default='public_ips',
+        search_global=False
     )
 
 

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -102,7 +102,7 @@ def get_conn():
     '''
     driver = get_driver(Provider.RACKSPACE)
     return driver(
-        config.get_config_value('user', vm_, __opts__)
+        config.get_config_value('user', vm_, __opts__),
         config.get_config_value('apikey', vm_, __opts__)
     )
 

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -104,8 +104,18 @@ def get_conn():
     '''
     driver = get_driver(Provider.RACKSPACE)
     return driver(
-        config.get_config_value('user', vm_, __opts__, search_global=False),
-        config.get_config_value('apikey', vm_, __opts__, search_global=False)
+        config.get_config_value(
+            'user',
+            get_configured_provider(),
+            __opts__,
+            search_global=False
+        ),
+        config.get_config_value(
+            'apikey',
+            get_configured_provider(),
+            __opts__,
+            search_global=False
+        )
     )
 
 

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -249,7 +249,8 @@ def create(vm_):
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))
-            ret['deploy_kwargs'] = deploy_kwargs
+            if __opts__.get('show_deploy_args', False) is True:
+                ret['deploy_kwargs'] = deploy_kwargs
         else:
             log.error(
                 'Failed to start Salt on Cloud VM {0}'.format(

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -77,7 +77,7 @@ def __virtual__():
     Set up the libcloud functions and check for Rackspace configuration.
     '''
     if get_configured_provider() is False:
-        log.info(
+        log.debug(
             'There is no Rackspace cloud provider configuration available. '
             'Not loading module.'
         )

--- a/saltcloud/clouds/saltify.py
+++ b/saltcloud/clouds/saltify.py
@@ -130,9 +130,11 @@ def create(vm_):
         'sudo': config.get_config_value(
             'sudo', vm_, __opts__, default=(ssh_username != 'root')
         ),
-        'password': config.get_config_value('password', vm_, __opts__),
+        'password': config.get_config_value(
+            'password', vm_, __opts__, search_global=False
+        ),
         'ssh_keyfile': config.get_config_value(
-            'ssh_keyfile', vm_, __opts__
+            'ssh_keyfile', vm_, __opts__, search_global=False
         ),
         'script_args': config.get_config_value(
             'script_args', vm_, __opts__

--- a/saltcloud/clouds/saltify.py
+++ b/saltcloud/clouds/saltify.py
@@ -111,6 +111,8 @@ def create(vm_):
             }
         }
 
+    ret = {}
+
     log.info('Provisioning existing machine {0}'.format(vm_['name']))
 
     ssh_username = config.get_config_value('ssh_username', vm_, __opts__)
@@ -156,8 +158,11 @@ def create(vm_):
 
     deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
     if deployed:
+        ret['deployed'] = deployed
         log.info('Salt installed on {0}'.format(vm_['name']))
-        return {vm_['name']: True}
+        if __opts__.get('show_deploy_args', False) is True:
+            ret['deploy_kwargs'] = deploy_kwargs
+        return ret
 
     log.error('Failed to start Salt on host {0}'.format(vm_['name']))
     return {

--- a/saltcloud/clouds/saltify.py
+++ b/saltcloud/clouds/saltify.py
@@ -134,6 +134,18 @@ def create(vm_):
             'minion_conf': saltcloud.utils.minion_conf_string(__opts__, vm_)
         }
 
+        # Deploy salt-master files, if necessary
+        if config.get_config_value('make_master', vm_, __opts__) is True:
+            deploy_kwargs['make_master'] = True
+            deploy_kwargs['master_pub'] = vm_['master_pub']
+            deploy_kwargs['master_pem'] = vm_['master_pem']
+            master_conf = saltcloud.utils.master_conf_string(__opts__, vm_)
+            if master_conf:
+                deploy_kwargs['master_conf'] = master_conf
+
+            if 'syndic_master' in master_conf:
+                deploy_kwargs['make_syndic'] = True
+
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
             log.info('Salt installed on {0}'.format(vm_['name']))

--- a/saltcloud/clouds/saltify.py
+++ b/saltcloud/clouds/saltify.py
@@ -5,8 +5,8 @@ The Saltify module is designed to install Salt on a remote machine, virtual or
 bare metal, using SSH. This module is useful for provisioning machines which
 are already installed, but not Salted.
 
-Use of this module requires no configuration in the main cloud config file.
-However, profiles must still be configured, as described in the saltify
+Use of this module requires no configuration in the main cloud configuration
+file. However, profiles must still be configured, as described in the saltify
 documentation.
 '''
 
@@ -24,13 +24,15 @@ import xml.etree.ElementTree as ET
 # Import salt libs
 import salt.utils.event
 import salt.utils.xmlutil
+
+# Import salt cloud libs
 import saltcloud.utils
+import saltcloud.config as config
 
 # Get logging started
 log = logging.getLogger(__name__)
 
 
-# Only load in this module if the PARALLELS configurations are in place
 def __virtual__():
     '''
     Needs no special configuration
@@ -40,60 +42,60 @@ def __virtual__():
 
 def avail_locations():
     '''
-    Because this module is not specific to any cloud providers, there will be no
-    locations to list.
+    Because this module is not specific to any cloud providers, there will be
+    no locations to list.
     '''
-    return {'Error':
-               {'Not Supported':
-                   '--list-locations not supported by Saltify'
-               }
-           }
+    return {
+        'Error': {
+            'Not Supported': '--list-locations not supported by Saltify'
+        }
+    }
 
 
 def avail_images():
     '''
-    Because this module is not specific to any cloud providers, there will be no
-    images to list.
+    Because this module is not specific to any cloud providers, there will be
+    no images to list.
     '''
-    return {'Error':
-               {'Not Supported':
-                   '--list-images not supported by Saltify'
-               }
-           }
+    return {
+        'Error': {
+            'Not Supported': '--list-images not supported by Saltify'
+        }
+    }
 
 
 def avail_sizes():
     '''
-    Because this module is not specific to any cloud providers, there will be no
-    sizes to list.
+    Because this module is not specific to any cloud providers, there will be
+    no sizes to list.
     '''
-    return {'Error':
-               {'Not Supported':
-                   '--list-sizes not supported by Saltify'
-               }
-           }
+    return {
+        'Error': {
+            'Not Supported': '--list-sizes not supported by Saltify'
+        }
+    }
 
 
 def list_nodes():
     '''
-    Because this module is not specific to any cloud providers, there will be no
-    nodes to list.
+    Because this module is not specific to any cloud providers, there will be
+    no nodes to list.
     '''
     return {}
 
 
 def list_nodes_full():
     '''
-    Because this module is not specific to any cloud providers, there will be no
-    nodes to list.
+    Because this module is not specific to any cloud providers, there will be
+    no nodes to list.
     '''
     return {}
 
 
 def list_nodes_select():
     '''
-    Because this module is not specific to any cloud providers, there will be no
-    nodes to list.
+    Because this module is not specific to any cloud providers, there will be
+    no nodes to list.
     '''
     return {}
 
@@ -103,13 +105,13 @@ def create(vm_):
     Provision a single machine
     '''
     log.info('Provisioning existing machine {0}'.format(vm_['name']))
-    deploy_script = script(vm_)
 
-    if __opts__['deploy'] is True:
+    if config.get_config_value('deploy', vm_, __opts__) is True:
         deploy_script = script(vm_)
+        ssh_username = config.get_config_value('ssh_username', vm_, __opts__)
         deploy_kwargs = {
             'host': vm_['ssh_host'],
-            'username': vm_['ssh_username'],
+            'username': ssh_username,
             'script': deploy_script,
             'name': vm_['name'],
             'deploy_command': '/tmp/deploy.sh',
@@ -119,20 +121,18 @@ def create(vm_):
             'minion_pem': vm_['priv_key'],
             'minion_pub': vm_['pub_key'],
             'keep_tmp': __opts__['keep_tmp'],
-            }
-
-        if 'password' in vm_:
-            deploy_kwargs['password'] = vm_['password']
-        elif 'ssh_keyfile' in vm_:
-            deploy_kwargs['key_filename'] = vm_['ssh_keyfile']
-
-        if 'sudo' in vm_:
-            deploy_kwargs['sudo'] = vm_['sudo']
-
-        if 'script_args' in vm_:
-            deploy_kwargs['script_args'] = vm_['script_args']
-
-        deploy_kwargs['minion_conf'] = saltcloud.utils.minion_conf_string(__opts__, vm_)
+            'sudo': config.get_config_value(
+                'sudo', vm_, __opts__, default=(ssh_username != 'root')
+            ),
+            'password': config.get_config_value('password', vm_, __opts__),
+            'ssh_keyfile': config.get_config_value(
+                'ssh_keyfile', vm_, __opts__
+            ),
+            'script_args': config.get_config_value(
+                'script_args', vm_, __opts__
+            ),
+            'minion_conf': saltcloud.utils.minion_conf_string(__opts__, vm_)
+        }
 
         deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
         if deployed:
@@ -149,14 +149,8 @@ def script(vm_):
     '''
     minion = saltcloud.utils.minion_conf_string(__opts__, vm_)
     script = saltcloud.utils.os_script(
-        saltcloud.utils.get_option(
-            'script',
-            __opts__,
-            vm_
-        ),
-        vm_,
-        __opts__,
-        minion,
+        config.get_config_value('script', vm_, __opts__),
+        vm_, __opts__, minion
     )
     return script
 
@@ -166,8 +160,9 @@ def destroy(name, call=None):
     Because this module is not specific to any cloud providers, it is not
     possible to destroy a node.
     '''
-    return {'Error':
-               {'Not Supported':
-                   '--destroy and --action destroy not supported by Saltify'
-               }
-           }
+    return {
+        'Error': {
+            'Not Supported': '--destroy and --action destroy not supported '
+                             'by Saltify'
+        }
+    }

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -237,3 +237,29 @@ def apply_cloud_providers_config(overrides, defaults=None):
         providers[key] = val
 
     return providers
+
+
+def get_config_value(name, vm_, opts, default=None):
+    '''
+    Search and return a setting in a known order:
+
+        1. In the virtual machines configuration
+        2. In the virtual machine's provider configuration
+        3. In the salt cloud configuration
+        4. Return the provided default
+    '''
+    if name in vm_:
+        # The setting name exists in VM configuration. Return it!
+        return vm_[name]
+
+    if name in opts['providers'][vm_['provider']]:
+        # The setting name exists in the VM's provider configuration.
+        # Return it!
+        return opts['providers'][vm_['provider']][name]
+
+    if name in opts:
+        # The setting name exists in the cloud(global) configuration
+        return opts[name]
+
+    # As a last resort, return the default
+    return default

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -403,7 +403,7 @@ def get_config_value(name, vm_, opts, default=None, search_global=True):
                         if name in entry:
                             return entry[name]
                         break
-        elif len(opts['providers'][vm_['provider']]) > 1:
+        elif len(opts['providers'].get(vm_['provider'], ())) > 1:
             # The provider is NOT defined as <provider-alias>:<provider-name>
             # and there's more than one entry under the alias.
             # WARN the user!!!!
@@ -417,7 +417,7 @@ def get_config_value(name, vm_, opts, default=None, search_global=True):
                 )
             )
 
-        if name in opts['providers'][vm_['provider']][0]:
+        if name in opts['providers'].get(vm_['provider'], [{}])[0]:
             # The setting name exists in the VM's provider configuration.
             # Return it!
             return opts['providers'][vm_['provider']][0][name]

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -263,7 +263,8 @@ def get_config_value(name, vm_, opts, default=None, search_global=True):
         # The setting name exists in VM configuration. Return it!
         return vm_[name]
 
-    if vm_ and name and name in opts['providers'][vm_['provider']]:
+    if vm_ and name and vm_['provider'] in opts['providers'] and \
+            name in opts['providers'][vm_['provider']]:
         # The setting name exists in the VM's provider configuration.
         # Return it!
         return opts['providers'][vm_['provider']][name]

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -362,7 +362,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
                 )
                 continue
             else:
-                extended = providers.get(extends)[0][:]
+                extended = providers.get(extends)[:][0]
 
             # Update the data to extend with the data to be extended
             extended.update(details)

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -186,10 +186,8 @@ def apply_vm_profiles_config(overrides, defaults=None):
         val['profile'] = key
         vms[key] = val
 
-    return vms.values()
-
     # Is any VM profile extending data!?
-    for profile, details in vms.copy():
+    for profile, details in vms.copy().items():
         if 'extends' not in details:
             continue
 

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -119,14 +119,19 @@ def apply_cloud_config(overrides, defaults=None):
 
 
 def old_to_new(opts):
-    providers = ('AWS',
-                 'EC2',
-                 'GOGRID',
-                 'IBMSCE',
-                 'JOYENT',
-                 'LINODE',
-                 'OPENSTACK',
-                 'RACKSPACE')
+    providers = (
+        'AWS',
+        'DIGITAL_OCEAN',
+        'EC2',
+        'GOGRID',
+        'IBMSCE',
+        'JOYENT',
+        'LINODE',
+        'OPENSTACK',
+        'PARALLELS'
+        'RACKSPACE',
+        'SALTIFY'
+    )
 
     for provider in providers:
 

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -112,6 +112,13 @@ def apply_cloud_config(overrides, defaults=None):
     if overrides:
         opts.update(overrides)
 
+    # If the user defined providers in salt cloud's main configuration file, we
+    # need to take care for proper and expected format.
+    if 'providers' in opts:
+        for alias, details in opts.copy()['providers'].items():
+            if isinstance(details, dict):
+                opts['providers'][alias] = [details]
+
     # Migrate old configuration
     opts = old_to_new(opts)
 

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -250,7 +250,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
     return providers
 
 
-def get_config_value(name, vm_, opts, default=None):
+def get_config_value(name, vm_, opts, default=None, search_global=True):
     '''
     Search and return a setting in a known order:
 
@@ -268,7 +268,7 @@ def get_config_value(name, vm_, opts, default=None):
         # Return it!
         return opts['providers'][vm_['provider']][name]
 
-    if opts.get(name, None) is not None:
+    if search_global is True and opts.get(name, None) is not None:
         # The setting name exists in the cloud(global) configuration
         return opts[name]
 

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -263,3 +263,31 @@ def get_config_value(name, vm_, opts, default=None):
 
     # As a last resort, return the default
     return default
+
+
+def is_provider_configured(opts, provider, required_keys=()):
+    for provider_details in opts['providers'].values():
+        if 'provider' not in provider_details:
+            continue
+
+        if provider_details['provider'] != provider:
+            continue
+
+        # If we reached this far, we have a matching provider, let's see if all
+        # required configuration keys are present and not None
+        skip_provider = False
+        for key in required_keys:
+            if provider_details.get(key, None) is None:
+                # This provider does not include all necessary keys, continue
+                # to next one
+                skip_provider = True
+                break
+
+        if skip_provider:
+            continue
+
+        # If we reached this far, the provider included all required keys
+        return provider_details
+
+    # If we reached this point, the provider is not configured.
+    return False

--- a/saltcloud/exceptions.py
+++ b/saltcloud/exceptions.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+'''
+    saltcloud.exceptions
+    ~~~~~~~~~~~~~~~~~~~~
+
+    Salt cloud related exceptions.
+
+    :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
+    :copyright: © 2013 by the SaltStack Team, see AUTHORS for more details.
+    :license: Apache 2.0, see LICENSE for more details.
+'''
+
+# Import salt libs
+from salt.exceptions import SaltException
+
+
+class SaltCloudException(SaltException):
+    '''
+    Generic Salt Cloud Exception
+    '''
+
+
+class SaltCloudSystemExit(SaltCloudException):
+    '''
+    This exception is raised when the execution should be stopped.
+    '''
+    def __init__(self, message, exit_code=1):
+        self.message = message
+        self.exit_code = exit_code

--- a/saltcloud/exceptions.py
+++ b/saltcloud/exceptions.py
@@ -27,3 +27,15 @@ class SaltCloudSystemExit(SaltCloudException):
     def __init__(self, message, exit_code=1):
         self.message = message
         self.exit_code = exit_code
+
+
+class SaltCloudConfigError(SaltCloudException):
+    '''
+    Raised when a configuration setting is not found and should exist.
+    '''
+
+
+class SaltCloudNotFound(SaltException):
+    '''
+    Raised when some cloud provider function cannot find what's being searched.
+    '''

--- a/saltcloud/libcloudfuncs.py
+++ b/saltcloud/libcloudfuncs.py
@@ -18,7 +18,10 @@ from libcloud.compute.deployment import (
 
 # Import salt libs
 import salt.utils.event
+
+# Import salt cloud libs
 import saltcloud.utils
+import saltcloud.config as config
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -40,7 +43,7 @@ def libcloud_version():
     try:
         import libcloud
     except ImportError:
-        raise ImportError("salt-cloud requires >= libcloud 0.11.4")
+        raise ImportError('salt-cloud requires >= libcloud 0.11.4')
 
     ver = libcloud.__version__
     ver = ver.replace('-', '.')
@@ -50,8 +53,8 @@ def libcloud_version():
         version.append(int(number))
     if version < [0, 11, 4]:
         raise ImportError(
-            "Your version of libcloud is {0}. salt-cloud requires >= "
-            "libcloud 0.11.4. Please upgrade.".format(libcloud.__version__)
+            'Your version of libcloud is {0}. salt-cloud requires >= '
+            'libcloud 0.11.4. Please upgrade.'.format(libcloud.__version__)
         )
     return libcloud.__version__
 
@@ -70,17 +73,15 @@ def ssh_pub(vm_):
     '''
     Deploy the primary ssh authentication key
     '''
-    ssh = ''
-    if 'ssh_auth' in vm_:
-        if not os.path.isfile(vm_['ssh_auth']):
-            return None
-        ssh = vm_['ssh_auth']
+    ssh = config.get_config_value('ssh_auth', vm_, __opts__)
     if not ssh:
-        if not os.path.isfile(__opts__['ssh_auth']):
-            return None
-        ssh = __opts__['ssh_auth']
+        return None
 
-    return SSHKeyDeployment(open(os.path.expanduser(ssh)).read())
+    ssh = os.path.expanduser(ssh)
+    if os.path.isfile(ssh):
+        return None
+
+    return SSHKeyDeployment(open(ssh).read())
 
 
 def avail_locations(conn=None):
@@ -148,12 +149,13 @@ def get_location(conn, vm_):
     Return the location object to use
     '''
     locations = conn.list_locations()
+    vm_location = config.get_config_value('location', vm_, __opts__)
+
     for img in locations:
-        if str(img.id) == str(vm_['location']):
+        if vm_location and str(vm_location) in (str(img.id), str(img.name)):
             return img
-        if img.name == str(vm_['location']):
-            return img
-    raise ValueError("The specified location could not be found.")
+
+    raise ValueError('The specified location could not be found.')
 
 
 def get_image(conn, vm_):
@@ -161,12 +163,14 @@ def get_image(conn, vm_):
     Return the image object to use
     '''
     images = conn.list_images()
+
+    vm_image = config.get_config_value('image', vm_, __opts__)
+
     for img in images:
-        if str(img.id) == str(vm_['image']):
+        if vm_image and str(vm_image) in (str(img.id), str(img.name)):
             return img
-        if img.name == str(vm_['image']):
-            return img
-    raise ValueError("The specified image could not be found.")
+
+    raise ValueError('The specified image could not be found.')
 
 
 def get_size(conn, vm_):
@@ -174,14 +178,14 @@ def get_size(conn, vm_):
     Return the VM's size object
     '''
     sizes = conn.list_sizes()
-    if not 'size' in vm_:
+    vm_size = config.get_config_value('size', vm_, __opts__)
+    if not vm_size:
         return sizes[0]
+
     for size in sizes:
-        if str(size.id) == str(vm_['size']):
+        if vm_size and str(vm_size) in (str(img.id), str(img.name)):
             return size
-        if str(size.name) == str(vm_['size']):
-            return size
-    raise ValueError("The specified size could not be found.")
+    raise ValueError('The specified size could not be found.')
 
 
 def script(vm_):
@@ -191,14 +195,8 @@ def script(vm_):
     minion = saltcloud.utils.minion_conf_string(__opts__, vm_)
     return ScriptDeployment(
         saltcloud.utils.os_script(
-            saltcloud.utils.get_option(
-                'os',
-                __opts__,
-                vm_
-            ),
-            vm_,
-            __opts__,
-            minion,
+            config.get_config_value('os', vm_, __opts__),
+            vm_, __opts__, minion
         )
     )
 
@@ -252,9 +250,9 @@ def reboot(name, conn=None):
         )
         event.fire_event('{0} has been rebooted'.format(name), 'salt-cloud')
         return True
-    else:
-        log.error('Failed to reboot VM: {0}'.format(name))
-        return False
+
+    log.error('Failed to reboot VM: {0}'.format(name))
+    return False
 
 
 def list_nodes(conn=None):

--- a/saltcloud/libcloudfuncs.py
+++ b/saltcloud/libcloudfuncs.py
@@ -22,6 +22,7 @@ import salt.utils.event
 # Import salt cloud libs
 import saltcloud.utils
 import saltcloud.config as config
+from saltcloud.exceptions import SaltCloudNotFound
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -155,7 +156,7 @@ def get_location(conn, vm_):
         if vm_location and str(vm_location) in (str(img.id), str(img.name)):
             return img
 
-    raise ValueError('The specified location could not be found.')
+    raise SaltCloudNotFound('The specified location could not be found.')
 
 
 def get_image(conn, vm_):
@@ -170,7 +171,7 @@ def get_image(conn, vm_):
         if vm_image and str(vm_image) in (str(img.id), str(img.name)):
             return img
 
-    raise ValueError('The specified image could not be found.')
+    raise SaltCloudNotFound('The specified image could not be found.')
 
 
 def get_size(conn, vm_):
@@ -185,7 +186,7 @@ def get_size(conn, vm_):
     for size in sizes:
         if vm_size and str(vm_size) in (str(size.id), str(size.name)):
             return size
-    raise ValueError('The specified size could not be found.')
+    raise SaltCloudNotFound('The specified size could not be found.')
 
 
 def script(vm_):

--- a/saltcloud/libcloudfuncs.py
+++ b/saltcloud/libcloudfuncs.py
@@ -183,7 +183,7 @@ def get_size(conn, vm_):
         return sizes[0]
 
     for size in sizes:
-        if vm_size and str(vm_size) in (str(img.id), str(img.name)):
+        if vm_size and str(vm_size) in (str(size.id), str(size.name)):
             return size
     raise ValueError('The specified size could not be found.')
 

--- a/saltcloud/loader.py
+++ b/saltcloud/loader.py
@@ -3,10 +3,22 @@ The salt cloud module loader interface
 '''
 # Import python libs
 import os
+import logging
 
 # Import Salt libs
 import salt.loader
 import saltcloud
+
+log = logging.getLogger(__name__)
+
+
+# Because on the cloud drivers we do `from saltcloud.libcloudfuncs import *`
+# which simplifies code readability, it adds some un-supported functions into
+# the driver's module scope.
+# We list un-supported functions here. These will be removed from the loaded.
+LIBCLOUD_FUNCS_NOT_SUPPORTED = (
+    'joyent.avail_locations',
+)
 
 
 def clouds(opts):
@@ -21,4 +33,13 @@ def clouds(opts):
             saltcloud.__file__
         )
     )
-    return load.gen_functions()
+    functions = load.gen_functions()
+    for funcname in CLOUD_FUNCS_NOT_SUPPORTED:
+        log.debug(
+            '{0!r} has been marked as not supported. Removing from the list '
+            'of supported cloud functions'.format(
+                funcname
+            )
+        )
+        functions.pop(funcname)
+    return functions

--- a/saltcloud/loader.py
+++ b/saltcloud/loader.py
@@ -41,5 +41,5 @@ def clouds(opts):
                 funcname
             )
         )
-        functions.pop(funcname)
+        functions.pop(funcname, None)
     return functions

--- a/saltcloud/loader.py
+++ b/saltcloud/loader.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 
 # Because on the cloud drivers we do `from saltcloud.libcloudfuncs import *`
-# which simplifies code readability, it adds some un-supported functions into
+# which simplifies code readability, it adds some unsupported functions into
 # the driver's module scope.
 # We list un-supported functions here. These will be removed from the loaded.
 LIBCLOUD_FUNCS_NOT_SUPPORTED = (
@@ -34,7 +34,7 @@ def clouds(opts):
         )
     )
     functions = load.gen_functions()
-    for funcname in CLOUD_FUNCS_NOT_SUPPORTED:
+    for funcname in LIBCLOUD_FUNCS_NOT_SUPPORTED:
         log.debug(
             '{0!r} has been marked as not supported. Removing from the list '
             'of supported cloud functions'.format(

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -14,6 +14,7 @@ import multiprocessing
 import logging
 import types
 import re
+import warnings
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -156,6 +157,18 @@ def get_option(option, opts, vm_):
     default to options set in the VM structure, but if the option is not
     present there look for it in the main config file
     '''
+    # Make the next warning visible at least once.
+    warnings.filterwarnings(
+        'once', category=DeprecationWarning, module='saltcloud'
+    )
+    warnings.warn(
+        '`saltcloud.utils.get_option() was deprecated in favour of '
+        '`saltcloud.config.get_config_value()`. Please stop using it '
+        'since it will be removed in version 0.8.8.',
+        DeprecationWarning,
+        stacklevel=2
+    )
+
     if option in vm_:
         return vm_[option]
     if option in opts:

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -25,10 +25,10 @@ import salt.client
 import salt.config
 import salt.utils
 import salt.utils.event
-from salt.exceptions import SaltException
 
 # Import salt cloud libs
 import saltcloud.config as config
+from saltcloud.exceptions import SaltCloudException
 
 # Import third party libs
 from jinja2 import Template
@@ -632,7 +632,7 @@ def check_name(name, safe_chars):
     '''
     regexp = re.compile('[^{0}]'.format(safe_chars))
     if regexp.search(name):
-        raise SaltException(
+        raise SaltCloudException(
             '{0} contains characters not supported by this cloud provider. '
             'Valid characters are: {1}'.format(
                 name, safe_chars

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -133,6 +133,7 @@ def remove_key(pki_dir, id_):
     key = os.path.join(pki_dir, 'minions', id_)
     if os.path.isfile(key):
         os.remove(key)
+        log.debug('Deleted {0!r}'.format(key))
 
 
 def rename_key(pki_dir, id_, new_id):

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -28,7 +28,7 @@ import salt.utils.event
 
 # Import salt cloud libs
 import saltcloud.config as config
-from saltcloud.exceptions import SaltCloudException
+from saltcloud.exceptions import SaltCloudConfigError, SaltCloudException
 
 # Import third party libs
 from jinja2 import Template
@@ -196,7 +196,9 @@ def minion_conf_string(opts, vm_):
     )
     make_master = config.get_config_value('make_master', vm_, opts)
     if 'master' not in minion and make_master is not True:
-        raise ValueError("A master was not defined.")
+        raise SaltCloudConfigError(
+            'A master setting was not defined in the minion\'s configuration.'
+        )
     minion.update(opts.get('map_minion', {}))
     minion.update(
         config.get_config_value(

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -267,6 +267,13 @@ class ExecutionOptionsMixIn(object):
             action='store_true',
             help='Do not remove files from /tmp/ after deploy.sh finishes.'
         )
+        group.add_option(
+            '--show-deploy-args',
+            default=False,
+            action='store_true',
+            help='Include the options used to deploy the minion in the data '
+                 'returned.'
+        )
         self.add_option_group(group)
 
     def process_function(self):

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -182,12 +182,12 @@ class ExecutionOptionsMixIn(object):
         )
         group.add_option(
             '-L', '--location',
-            default='',
+            default=None,
             help='Specify which region to connect to.'
         )
         group.add_option(
             '-a', '--action',
-            default='',
+            default=None,
             help='Perform an action that may be specific to this cloud '
                  'provider. This argument requires one or more instance '
                  'names to be specified.'
@@ -195,7 +195,7 @@ class ExecutionOptionsMixIn(object):
         group.add_option(
             '-f', '--function',
             nargs=2,
-            default='',
+            default=None,
             metavar='<FUNC-NAME> <PROVIDER>',
             help='Perform an function that may be specific to this cloud '
                  'provider, that does not apply to an instance. This '
@@ -203,12 +203,12 @@ class ExecutionOptionsMixIn(object):
         )
         group.add_option(
             '-p', '--profile',
-            default='',
+            default=None,
             help='Create an instance using the specified profile.'
         )
         group.add_option(
             '-m', '--map',
-            default='',
+            default=None,
             help='Specify a cloud map file to use for deployment. This option '
                  'may be used alone, or in conjunction with -Q, -F, -S or -d.'
         )

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -27,6 +27,7 @@ class CloudConfigMixIn(object):
         self.master_config = {}
         self.cloud_config = {}
         self.profiles_config = {}
+        self.providers_config = {}
         group = self.config_group = optparse.OptionGroup(
             self,
             "Configuration Options",
@@ -49,6 +50,12 @@ class CloudConfigMixIn(object):
             default=None,
             help='The location of the saltcloud VM config file. '
                  'Default: /etc/salt/cloud.profiles'
+        )
+        group.add_option(
+            '--providers-config',
+            default=None,
+            help='The location of the salt cloud VM providers '
+                 'configuration file. Default: /etc/salt/cloud.providers'
         )
         self.add_option_group(group)
 
@@ -84,7 +91,20 @@ class CloudConfigMixIn(object):
         # Loaded in CloudConfigMixIn.process_vm_config()
         self.config['vm'] = self.profiles_config
 
-        # 4th - Override config with cli options
+        # 4th - Include Cloud Providers
+        if 'providers' in self.config and self.providers_config:
+            self.error(
+                'Do not mix the old cloud providers configuration with '
+                'the new one. The providers configuration should now go in '
+                'the file `/etc/salt/cloud.providers` or a separate `*.conf` '
+                'file within `cloud.providers.d/` which is relative to '
+                '`/etc/salt/cloud.providers`. To provide another location '
+                'for the providers configuration file, please use '
+                '`--providers-config`.'
+            )
+        self.config['providers'] = self.providers_config
+
+        # 5th - Override config with cli options
         # Done in parsers.MergeConfigMixIn.__merge_config_with_cli()
 
         # Remove log_level_logfile from config if set to None so it can be
@@ -120,6 +140,13 @@ class CloudConfigMixIn(object):
             self.options.vm_config = self.cloud_config.get(
                 'vm_config', '/etc/salt/cloud.profiles'
             )
+        if self.options.providers_config is None:
+            # No providers config was provided from cli
+            # Set the profiles configuration file path to the one provided in
+            # the cloud's configuration or the default path.
+            self.options.providers_config = self.cloud_config.get(
+                'providers_config', '/etc/salt/cloud.providers'
+            )
 
     def process_master_config(self):
         self.master_config = salt.config.master_config(
@@ -132,8 +159,15 @@ class CloudConfigMixIn(object):
         self.profiles_config = config.vm_profiles_config(
             self.options.vm_config
         )
-    # Force process_vm_config to run AFTER process_cloud_config
+    # Force process_vm_config to run AFTER process_master_config
     process_vm_config._mixin_prio_ = -998
+
+    def process_providers_config(self):
+        self.providers_config = config.cloud_providers_config(
+            self.options.providers_config
+        )
+    # Force process_providers_config to run AFTER process_vm_config
+    process_providers_config._mixin_prio_ = -997
 
 
 class ExecutionOptionsMixIn(object):
@@ -154,18 +188,18 @@ class ExecutionOptionsMixIn(object):
         group.add_option(
             '-a', '--action',
             default='',
-            help=('Perform an action that may be specific to this cloud '
-                  'provider. This argument requires one or more instance '
-                  'names to be specified.')
+            help='Perform an action that may be specific to this cloud '
+                 'provider. This argument requires one or more instance '
+                 'names to be specified.'
         )
         group.add_option(
             '-f', '--function',
             nargs=2,
             default='',
             metavar='<FUNC-NAME> <PROVIDER>',
-            help=('Perform an function that may be specific to this cloud '
-                  'provider, that does not apply to an instance. This '
-                  'argument requires a provider to be specified (i.e.: nova).')
+            help='Perform an function that may be specific to this cloud '
+                 'provider, that does not apply to an instance. This '
+                 'argument requires a provider to be specified (i.e.: nova).'
         )
         group.add_option(
             '-p', '--profile',

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -13,10 +13,11 @@ from functools import partial
 
 # Import salt libs
 import salt.config
-from salt.utils import parsers
+import salt.utils.parsers as parsers
 
 # Import salt cloud libs
-from saltcloud import config, version
+import saltcloud.config as config
+import saltcloud.version as version
 
 
 class CloudConfigMixIn(object):
@@ -111,6 +112,13 @@ class CloudConfigMixIn(object):
         # equal to console log_level
         if self.config['log_level_logfile'] is None:
             self.config.pop('log_level_logfile')
+
+        if 'DUMP_SALT_CLOUD_CONFIG' in os.environ:
+            import pprint
+
+            print('Salt cloud configuration dump(INCLUDES SENSIBLE DATA):')
+            pprint.pprint(self.config)
+            self.exit(0)
 
     def setup_config(self):
         '''

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -103,7 +103,8 @@ class CloudConfigMixIn(object):
                 'for the providers configuration file, please use '
                 '`--providers-config`.'
             )
-        self.config['providers'] = self.providers_config
+        elif 'providers' not in self.config:
+            self.config['providers'] = self.providers_config
 
         # 5th - Override config with cli options
         # Done in parsers.MergeConfigMixIn.__merge_config_with_cli()


### PR DESCRIPTION
Enforce the new providers configuration. Refs #239:
- Updated the `old_to_new()` function to produce a more salt like syntax.
- Added a cli option argument to allow providing a different file which would contain the several cloud providers configuration.
- Besides the separate file for the could providers configuration, we also added support to include any `*.conf` file from `cloud.providers.d/` which is relative to the parent directory of the provided cloud providers configuration file.
- Update the several documentation files in order to include examples of both the old and new cloud providers configuration syntax side-to-side.
