### PR TITLE
Add support for block device mappings in AWS.

### DIFF
--- a/doc/topics/aws.rst
+++ b/doc/topics/aws.rst
@@ -194,6 +194,18 @@ Multiple security groups can also be specified in the same fashion:
       - default
       - extra
 
+Block device mappings enable you to specify additional EBS volumes or instance
+store volumes when the instance is launched. This setting is also available on
+each cloud profile:
+
+.. code-block:: yaml
+
+    AWS.block_device_mappings:
+        - DeviceName: /dev/sdb
+          VirtualName: ephemeral0
+        - DeviceName: /dev/sdc
+          VirtualName: ephemeral1
+
 
 Modify AWS Tags
 ===============

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -166,6 +166,18 @@ def securitygroup(vm_):
     return securitygroups
 
 
+def block_device_mappings(vm_):
+    '''
+    Return the block device mapping
+    e.g. [{'DeviceName': '/dev/sdb', 'VirtualName': 'ephemeral0'},
+          {'DeviceName': '/dev/sdc', 'VirtualName': 'ephemeral1'}]
+    '''
+    block_device_mappings = vm_.get(
+        'block_device_mappings', __opts__.get('AWS.block_device_mappings', None)
+    )
+    return block_device_mappings
+
+
 def ssh_username(vm_):
     '''
     Return the ssh_username. Defaults to 'ec2-user'.
@@ -247,6 +259,9 @@ def create(vm_):
     ex_securitygroup = securitygroup(vm_)
     if ex_securitygroup:
         kwargs['ex_securitygroup'] = ex_securitygroup
+    ex_blockdevicemappings = block_device_mappings(vm_)
+    if ex_blockdevicemappings:
+        kwargs['ex_blockdevicemappings'] = ex_blockdevicemappings
 
     try:
         data = conn.create_node(**kwargs)


### PR DESCRIPTION
This adds support for AWS block device mappings (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html)

This requires libcloud >= 0.12.1 (http://svn.apache.org/viewvc/libcloud/trunk/libcloud/compute/drivers/ec2.py?r1=1438350&r2=1438349&pathrev=1438350)
