### PR TITLE
Added the LON variant identity_url

### DIFF
--- a/doc/topics/rackspace.rst
+++ b/doc/topics/rackspace.rst
@@ -41,6 +41,11 @@ Rackspace currently has three compute regions which may be used:
     ORD -> Chicago
     LON -> London
 
+Note: if you are using LON with a UK account, you must use the following identity_url:
+
+.. code-block:: yaml
+
+    OPENSTACK.identity_url: 'https://lon.identity.api.rackspacecloud.com/v2.0/tokens'
 
 Authentication
 ==============


### PR DESCRIPTION
I was plugging in salt-cloud with a UK Rackspace account - after a while fumbling around as to why it wasn't liking me - I realised the authentication URL has lon prepended.

I figured a small note in the docs would be useful for the next guy : )
