### PR TITLE
Allow the download of the bootstrap script to be skipped. Fixes #517.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 import urllib2
 from distutils import log
 from distutils.core import setup
-from distutils.command.build import build as distutils_build
+from distutils.command.sdist import sdist as original_sdist
 
 setup_kwargs = {}
 USE_SETUPTOOLS = False
@@ -25,6 +25,7 @@ BOOTSTRAP_SCRIPT_DISTRIBUTED_VERSION = os.environ.get(
 if 'USE_SETUPTOOLS' in os.environ:
     try:
         from setuptools import setup
+        from setuptools.command import sdist as original_sdist
         USE_SETUPTOOLS = True
         saltcloud_reqs = os.path.join(SALTCLOUD_SOURCE_DIR, 'requirements.txt')
         requirements = ''
@@ -46,23 +47,23 @@ exec(
 )
 
 
-class build(distutils_build):
-    user_options = distutils_build.user_options + [
+class sdist(original_sdist):
+    user_options = original_sdist.user_options + [
         ('skip-bootstrap-download', None,
          'Skip downloading the bootstrap-salt.sh script. This can also be '
          'triggered by having `SKIP_BOOTSTRAP_DOWNLOAD=1` as an environment '
          'variable.')
     ]
-    boolean_options = distutils_build.boolean_options + [
+    boolean_options = original_sdist.boolean_options + [
         'skip-bootstrap-download'
     ]
 
     def initialize_options(self):
-        distutils_build.initialize_options(self)
+        original_sdist.initialize_options(self)
         self.skip_bootstrap_download = False
 
     def finalize_options(self):
-        distutils_build.finalize_options(self)
+        original_sdist.finalize_options(self)
         if 'SKIP_BOOTSTRAP_DOWNLOAD' in os.environ:
             skip_bootstrap_download = os.environ.get(
                 'SKIP_BOOTSTRAP_DOWNLOAD', '0'
@@ -111,7 +112,7 @@ class build(distutils_build):
                 )
 
         # Let's the rest of the build command
-        distutils_build.run(self)
+        original_sdist.run(self)
 
 
 NAME = 'salt-cloud'
@@ -149,7 +150,7 @@ setup(name=NAME,
                   ],
       scripts=['scripts/salt-cloud'],
       cmdclass={
-          'build': build
+          'sdist': sdist
       },
       **setup_kwargs
       )

--- a/setup.py
+++ b/setup.py
@@ -47,42 +47,68 @@ exec(
 
 
 class build(distutils_build):
-    def run(self):
-        # Let's update the bootstrap-script to the version defined to be
-        # distributed. See BOOTSTRAP_SCRIPT_DISTRIBUTED_VERSION above.
-        url = (
-            'https://github.com/saltstack/salt-bootstrap/raw/{0}'
-            '/bootstrap-salt.sh'.format(
-                BOOTSTRAP_SCRIPT_DISTRIBUTED_VERSION
+    user_options = distutils_build.user_options + [
+        ('skip-bootstrap-download', None,
+         'Skip downloading the bootstrap-salt.sh script. This can also be '
+         'triggered by having `SKIP_BOOTSTRAP_DOWNLOAD=1` as an environment '
+         'variable.')
+    ]
+    boolean_options = distutils_build.boolean_options + [
+        'skip-bootstrap-download'
+    ]
+
+    def initialize_options(self):
+        distutils_build.initialize_options(self)
+        self.skip_bootstrap_download = False
+
+    def finalize_options(self):
+        distutils_build.finalize_options(self)
+        if 'SKIP_BOOTSTRAP_DOWNLOAD' in os.environ:
+            skip_bootstrap_download = os.environ.get(
+                'SKIP_BOOTSTRAP_DOWNLOAD', '0'
             )
-        )
-        req = urllib2.urlopen(url)
-        deploy_path = os.path.join(
-            SALTCLOUD_SOURCE_DIR, 'saltcloud', 'deploy', 'bootstrap-salt.sh'
-        )
-        if req.getcode() == 200:
-            try:
-                log.info(
-                    'Updating bootstrap-salt.sh.'
-                    '\n\tSource:      {0}'
-                    '\n\tDestination: {1}'.format(
-                        url,
-                        deploy_path
+            self.skip_bootstrap_download = skip_bootstrap_download == '1'
+
+    def run(self):
+        if self.skip_bootstrap_download is False:
+            # Let's update the bootstrap-script to the version defined to be
+            # distributed. See BOOTSTRAP_SCRIPT_DISTRIBUTED_VERSION above.
+            url = (
+                'https://github.com/saltstack/salt-bootstrap/raw/{0}'
+                '/bootstrap-salt.sh'.format(
+                    BOOTSTRAP_SCRIPT_DISTRIBUTED_VERSION
+                )
+            )
+            req = urllib2.urlopen(url)
+            deploy_path = os.path.join(
+                SALTCLOUD_SOURCE_DIR,
+                'saltcloud',
+                'deploy',
+                'bootstrap-salt.sh'
+            )
+            if req.getcode() == 200:
+                try:
+                    log.info(
+                        'Updating bootstrap-salt.sh.'
+                        '\n\tSource:      {0}'
+                        '\n\tDestination: {1}'.format(
+                            url,
+                            deploy_path
+                        )
+                    )
+                    with open(deploy_path, 'w') as fp_:
+                        fp_.write(req.read())
+                except (OSError, IOError), err:
+                    log.error(
+                        'Failed to write the updated script: {0}'.format(err)
+                    )
+            else:
+                log.error(
+                    'Failed to update the bootstrap-salt.sh script. HTTP '
+                    'Error code: {0}'.format(
+                        req.getcode()
                     )
                 )
-                with open(deploy_path, 'w') as fp_:
-                    fp_.write(req.read())
-            except (OSError, IOError), err:
-                log.error(
-                    'Failed to write the updated script: {0}'.format(err)
-                )
-        else:
-            log.error(
-                'Failed to update the bootstrap-salt.sh script. HTTP Error '
-                'code: {0}'.format(
-                    req.getcode()
-                )
-            )
 
         # Let's the rest of the build command
         distutils_build.run(self)


### PR DESCRIPTION
Either passing `--skip-bootstrap-download` to `setup.py build` or by having `SKIP_BOOTSTRAP_DOWNLOAD=1` as an environment variable.
