### PR TITLE
Allow config to inherit/override in order of importance

### DIFF
--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -389,9 +389,12 @@ def get_config_value(name, vm_, opts, default=None, search_global=True):
         3. In the salt cloud configuration if global searching is enabled
         4. Return the provided default
     '''
-    if name and vm_ and name in vm_:
-        # The setting name exists in VM configuration. Return it!
-        return vm_[name]
+    # As a last resort, return the default
+    value = default
+
+    if search_global is True and opts.get(name, None) is not None:
+        # The setting name exists in the cloud(global) configuration
+        value = opts[name]
 
     if vm_ and name:
         if ':' in vm_['provider']:
@@ -401,8 +404,11 @@ def get_config_value(name, vm_, opts, default=None, search_global=True):
                 for entry in opts['providers'][alias]:
                     if entry['provider'] == provider:
                         if name in entry:
-                            return entry[name]
-                        break
+                            if type(value) is dict:
+                                value.update(entry[name])
+                            else:
+                                value = entry[name]
+                            break
         elif len(opts['providers'].get(vm_['provider'], ())) > 1:
             # The provider is NOT defined as <provider-alias>:<provider-name>
             # and there's more than one entry under the alias.
@@ -420,14 +426,19 @@ def get_config_value(name, vm_, opts, default=None, search_global=True):
         if name in opts['providers'].get(vm_['provider'], [{}])[0]:
             # The setting name exists in the VM's provider configuration.
             # Return it!
-            return opts['providers'][vm_['provider']][0][name]
+            if type(value) is dict:
+                value.update(opts['providers'][vm_['provider']][0][name])
+            else:
+                value = opts['providers'][vm_['provider']][0][name]
 
-    if search_global is True and opts.get(name, None) is not None:
-        # The setting name exists in the cloud(global) configuration
-        return opts[name]
+    if name and vm_ and name in vm_:
+        # The setting name exists in VM configuration.
+        if type(value) is dict:
+            value.update(vm_[name])
+        else:
+            value = vm_[name]
 
-    # As a last resort, return the default
-    return default
+    return value
 
 
 def is_provider_configured(opts, provider, required_keys=()):


### PR DESCRIPTION
This patch fixes a regression as described below. It may or may not be how you want to do things in salt-cloud now...

Previously I could define more general options in the high level config files and then override them in lower config files. This order was used:
1. `/etc/salt/cloud`
2. `/etc/salt/cloud.profiles`
3. map file

Now we have the newer `.providers` file to contend with as well.

In my specific case, the following config files meant the `minion` entry in `.profiles` was overwriting the entry in `.providers`. (Thanks @whiteinge!)

```
> cat /etc/salt/cloud.providers
singapore-config:
  provider: ec2

  minion:
    master: salt-master.example.com
    master_finger: 5b:********:1d

  id: '********'
  key: '********'
  keyname: keyname
  securitygroup: default
  private_key: key.pem

> cat /etc/salt/cloud.profiles
app_server:
  provider: singapore-config
  image: ami-6686ca34
  size: Small Instance
  minion:
    grains:
      role: app
```
