### PR TITLE
#540 hardcoded to use public ip for deploy.sh ssh calls

### DIFF
--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -174,9 +174,13 @@ def create(vm_):
 
     ret = {}
     if config.get_config_value('deploy', vm_, __opts__) is True:
+        host = data.public_ips[0] 
+        if ssh_interface(vm_) == 'private_ips':
+            host = data.private_ips[0]
+
         deploy_script = script(vm_)
         deploy_kwargs = {
-            'host': data.public_ips[0],
+            'host': host,
             'username': 'root',
             'key_filename': key_filename,
             'script': deploy_script.script,
@@ -263,6 +267,17 @@ def stop(name, call=None):
         )
 
     return data
+
+def ssh_interface(vm_):
+    '''
+    Return the ssh_interface type to connect to. Either 'public_ips' (default)
+    or 'private_ips'.
+    '''
+    return config.get_config_value(
+        'ssh_interface', vm_, __opts__, default='public_ips',
+        search_global=False
+    )
+
 
 
 def get_location(vm_=None):


### PR DESCRIPTION
I have introduced the code to check the vm configuration for the key ssh_interface. 

If set to priviate_ips, it will use the private ip to deploy, which is intended for when the salt-master/salt-cloud server is inside the data-center.

eg:

joyent-centos-small:
    provider: joyent-sw-cloud
    image: centos-6
    ssh_interface: private_ips
    script: RHEL6
    size: Extra Small 512 MB
