### PR TITLE
changed to allow extending libcloud drivers

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -224,8 +224,8 @@ class SaltCloud(parsers.SaltCloudParser):
             )
             if prov_func not in mapper.clouds:
                 self.error(
-                    'The {0!r} provider does not define the function '
-                    '{1!r}'.format(
+                    'The {1!r} provider does not define the function '
+                    '{0!r}'.format(
                         self.function_provider, self.function_name
                     )
                 )

--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -218,15 +218,22 @@ class SaltCloud(parsers.SaltCloudParser):
                 self.handle_exception(msg, exc)
 
         elif self.options.function:
+            try:
+                if self.function_provider in  self.config['providers']:
+                    self.function_provider = self.config['providers'][self.function_provider][0]['provider']
+            except:
+                pass
+
             prov_func = '{0}.{1}'.format(
-                self.function_name,
                 self.function_provider,
+                self.function_name,
             )
             if prov_func not in mapper.clouds:
                 self.error(
-                    'The {1!r} provider does not define the function '
-                    '{0!r}'.format(
-                        self.function_provider, self.function_name
+                    'The {0!r} provider does not define the function '
+                    '{1!r}'.format(
+                        self.function_provider, 
+                        self.function_name,
                     )
                 )
 
@@ -238,7 +245,7 @@ class SaltCloud(parsers.SaltCloudParser):
 
             try:
                 ret = mapper.do_function(
-                    self.function_provider, self.function_name, kwargs
+                    self.function_name, self.function_provider, kwargs
                 )
             except (SaltCloudException, Exception) as exc:
                 msg = 'There was an error running the function: {0}'

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -838,9 +838,9 @@ class Map(Cloud):
                             tvm['map_minion'] = miniondict[name]['minion']
                         if 'volumes' in miniondict[name]:
                             tvm['map_volumes'] = miniondict[name]['volumes']
-                for myvar in miniondict[name]:
-                    if myvar not in ('grains', 'minion', 'volumes'):
-                        tvm[myvar] = miniondict[name][myvar]
+                    for myvar in miniondict[name]:
+                        if myvar not in ('grains', 'minion', 'volumes'):
+                            tvm[myvar] = miniondict[name][myvar]
             if 'minion' not in tvm:
                 tvm['minion'] = tvm['map_minion']
             if self.opts['parallel']:

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -48,6 +48,7 @@ import saltcloud.utils
 import saltcloud.config as config
 from saltcloud.utils import namespaced_function
 
+
 # Get logging started
 log = logging.getLogger(__name__)
 
@@ -106,7 +107,7 @@ def get_conn(location=DEFAULT_LOCATION):
     '''
     Return a conn object for the passed VM data
     '''
-    driver = get_driver(Provider.JOYENT)
+    driver = get_extended_driver(Provider.JOYENT)
 
     log.debug("Loading driver for connection to {0}".format(location))
 
@@ -247,7 +248,7 @@ def reboot(name, call=None):
 
         salt-cloud -a reboot mymachine
     '''
-    return __take_action(name, call, 'reboot_node','Rebooting','reboot')
+    return __take_action(name, call, 'reboot_node','Rebooted','reboot')
 
 
 def stop(name, call=None):
@@ -269,7 +270,7 @@ def start(name, call=None):
 
         salt-cloud -a stop mymachine
     '''
-    return __take_action(name,call,'start_node','Started','start')
+    return __take_action(name,call,'sc_start_node','Started','start')
 
     
 def __take_action(name, call=None, action = None, atext= None, btext=None):

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -272,7 +272,6 @@ def start(name, call=None):
     '''
     return __take_action(name,call,'sc_start_node','Started','start')
 
-    
 def __take_action(name, call=None, action = None, atext= None, btext=None):
     data = {}
 
@@ -319,10 +318,6 @@ def ssh_interface(vm_):
         search_global=False
     )
 
-
-
-
-
 def get_location(vm_=None):
     '''
     Return the joyent datacenter to use, in this order:
@@ -355,14 +350,20 @@ def avail_locations():
 
     return ret
 
-def __query_request(conn,function):
+def __execute_function(call=None, function=None, params={}):
+    if call != 'function':
+        raise SaltCloudSystemExit(
+            'This function must be called with -f or --function.'
+            )
     data = {}
-    if conn is None:
-        conn = get_conn(get_location())
+    conn = get_conn(get_location())
     if not conn_has_method(conn, function):
         return data
     data = getattr(conn, function)()
     return data
 
-def list_ssh_keys(conn=None,call=None):
-    return __query_request(conn,'sc_list_ssh_keys');
+
+
+def list_ssh_keys(kwargs={}, call=None):
+    return __execute_function(call,'sc_list_ssh_keys');
+

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -321,6 +321,8 @@ def ssh_interface(vm_):
 
 
 
+
+
 def get_location(vm_=None):
     '''
     Return the joyent datacenter to use, in this order:
@@ -353,16 +355,14 @@ def avail_locations():
 
     return ret
 
-def has_method(obj, method_name):
-    ret = dir( obj )
+def __query_request(conn,function):
+    data = {}
+    if conn is None:
+        conn = get_conn(get_location())
+    if not conn_has_method(conn, function):
+        return data
+    data = getattr(conn, function)()
+    return data
 
-    if method_name in dir(obj):
-        return True;
-
-    log.error(
-            "Method '{0}' not yet supported!".format(
-                method_name
-            )
-    )
-    return False;
-
+def list_ssh_keys(conn=None,call=None):
+    return __query_request(conn,'sc_list_ssh_keys');

--- a/saltcloud/drivers/joyent.py
+++ b/saltcloud/drivers/joyent.py
@@ -1,0 +1,39 @@
+'''
+
+    libcloud joyent driver exension
+
+'''
+# import libcloud common libraries/methods
+from saltcloud.libcloudfuncs import *
+
+# import joyent sepcific driver classes
+from libcloud.compute.drivers.joyent import (
+    JoyentNodeDriver,
+    JoyentConnection,
+    JoyentResponse
+    )
+
+
+class ExtendedJoyentNodeDriver(JoyentNodeDriver):
+    """
+    Extended Joyent node driver class.
+    """
+
+    def __init__(self,*args,**kwargs):
+        super(ExtendedJoyentNodeDriver,self).__init__(*args,**kwargs)
+
+
+
+    def sc_start_node(self,node):
+        """
+        start node
+
+        @param  node: The node to be started
+        @type   node: L{Node}
+
+        @rtype: C{bool}
+        """
+        data = json.dumps({'action': 'start'})
+        result = self.connection.request('/my/machines/%s' % (node.id), 
+                data=data, method='POST')
+        return result.status == httplib.ACCEPTED

--- a/saltcloud/drivers/joyent.py
+++ b/saltcloud/drivers/joyent.py
@@ -6,6 +6,7 @@
 # import libcloud common libraries/methods
 from saltcloud.libcloudfuncs import *
 import urllib
+from pprint import pprint
 
 # import joyent sepcific driver classes
 from libcloud.compute.drivers.joyent import (
@@ -13,6 +14,7 @@ from libcloud.compute.drivers.joyent import (
     JoyentConnection,
     JoyentResponse
     )
+
 
 
 class ExtendedJoyentNodeDriver(JoyentNodeDriver):
@@ -28,9 +30,12 @@ class ExtendedJoyentNodeDriver(JoyentNodeDriver):
         result = self.connection.request(url,data=data,method='POST') 
         return result.status == httplib.ACCEPTED
 
-    def __get_request(self,url):
+    def __get_request(self,url, dataHandler=None):
         result = self.connection.request(url,method='GET') 
-        return result.status == httplib.ACCEPTED
+        if result.status == httplib.OK:
+            return json.loads(result.body)
+        return result.status == httplib.OK
+
 
     def __delete_request(self,url):
         result = self.connection.request(url,method='DELETE') 

--- a/saltcloud/drivers/joyent.py
+++ b/saltcloud/drivers/joyent.py
@@ -5,6 +5,7 @@
 '''
 # import libcloud common libraries/methods
 from saltcloud.libcloudfuncs import *
+import urllib
 
 # import joyent sepcific driver classes
 from libcloud.compute.drivers.joyent import (
@@ -23,6 +24,17 @@ class ExtendedJoyentNodeDriver(JoyentNodeDriver):
         super(ExtendedJoyentNodeDriver,self).__init__(*args,**kwargs)
 
 
+    def __post_request(self,url,data=""):
+        result = self.connection.request(url,data=data,method='POST') 
+        return result.status == httplib.ACCEPTED
+
+    def __get_request(self,url):
+        result = self.connection.request(url,method='GET') 
+        return result.status == httplib.ACCEPTED
+
+    def __delete_request(self,url):
+        result = self.connection.request(url,method='DELETE') 
+        return result.status == httplib.ACCEPTED
 
     def sc_start_node(self,node):
         """
@@ -34,6 +46,100 @@ class ExtendedJoyentNodeDriver(JoyentNodeDriver):
         @rtype: C{bool}
         """
         data = json.dumps({'action': 'start'})
-        result = self.connection.request('/my/machines/%s' % (node.id), 
-                data=data, method='POST')
+        return self.__post_request('/my/machines/%s' % (node.id),data)
+
+    def sc_create_node_snapshot(self, node, name):
+        data = json.dumps({'name': name })
+        return self.__post_request('/my/machines/%s/snapshots' % (node.id), data)
+
+    def sc_start_node_snapshot(self, node, name):
+        return self.__post_request('/my/machines/%s/snapshots/%s' % (node.id,name))
+
+    def sc_list_snapshots(self, node):
+        return self.__get_request('/my/machines/%s/snapshots' % (node.id,name))
+
+    def sc_get_node_snapshot(self, node, name):
+        return self.__get_request('/my/machines/%s/snapshots/%s' % (node.id,name))
+
+    def sc_del_node_snapshot(self, node, name):
+        return self.connection.request('/my/machines/%s/snapshots/%s' % (node.id,name))
+
+    def sc_update_node_metadata(self,node,key,value):
+        data = json.dumps({key: value})
+        return self.__post_request('/my/machines/%s/metadata' % (node.id), data)
+
+    def sc_get_node_metadata(self,node):
+        return self.__get_request('/my/machines/%s/metadata' % (node.id))
+
+    def sc_del_node_metadata(self,node,key):
+        return self.__delete_request('/my/machines/%s/metadata/%s' % (node.id,key))
+
+    def sc_del_all_node_metadata(self,node):
+        return self.__delete_request('/my/machines/%s/metadata' % (node.id))
+
+    def sc_update_node_tags(self,node, kvps):
+        data = urllib.urlencode(kvps)
+        return self.__post_request('/my/machines/%s/tags' % (node.id), data)
+
+    def sc_get_node_tags(self,node):
+        return self.__get_request('/my/machines/%s/tags' % (node.id))
+    
+    def sc_get_node_tag(self,node,tag):
+        return self.__get_request('/my/machines/%s/tags/%s' % (node.id,tag))
+
+    def sc_del_node_tag(self,node,key):
+        return self.__delete_request('/my/machines/%s/tags/%s' % (node.id,key))
+
+    def sc_del_all_node_tags(self,node):
+        return self.__delete_request('/my/machines/%s/tags' % (node.id))
+
+    def sc_describe_analytics(self):
+        return self.__get_request('/my/machines/analytics')
+
+    def sc_list_instrumenations(self):
+        return self.__get_request('/my/machines/analytics/instrumentations')
+
+    def sc_get_instrumentation(self,id):
+        return self.__get_request("/my/machines/analytics/instrumentations/{0}".format(id))
+
+    def sc_get_instrumentationValue(self,id):
+        return self.__get_request(
+                "/my/machines/analytics/instrumentations/{0}/value/raw".format(id))
+
+    def sc_get_instrumentationHeatmap(self,id):
+        return self.__get_request(
+                "/my/machines/analytics/instrumentations/{0}/value/heatmap/image".format(id))
+
+    def sc_get_instrumentationHeatmapDetails(self,id):
+        return self.__get_request(
+                "/my/machines/analytics/instrumentations/{0}/value/heatmap/details".format(id))
+
+    def sc_create_instrumentation(self,kvps):
+        data = urllib.urlencode(kvps)
+        return self.__post_request(
+                "/my/machines/analytics/instrumentations".format(id), 
+                data)
         return result.status == httplib.ACCEPTED
+
+    def sc_del_instrumentation(self,id):
+        return self.__delete_request('/my/machines/instrumentations/{0}'.format(node.id))
+
+    def sc_list_ssh_keys(self):
+        return self.__get_request("/my/machines/keys")
+
+    def sc_get_key(self,keyname):
+        return self.__get_request("/my/machines/%s" % keyname )
+
+    def sc_create_key(self,keyname,key):
+        data = json.dumps({'name': keyname, 'key':key })
+        return self.__post_request("/my/machines/keys", data)
+
+    def sc_delete_key(self,keyname):
+        return self.__delete_request("/my/machines/keys/%s" % keyname)
+
+    def sc_list_datacenters(self):
+        return self.__get_request("/my/machines/datacenters")
+
+    def sc_get_datacenter(self,dc):
+        return self.__get_request("/my/machines/datacenters/%s" % dc)
+

--- a/saltcloud/drivers/joyent.py
+++ b/saltcloud/drivers/joyent.py
@@ -119,7 +119,6 @@ class ExtendedJoyentNodeDriver(JoyentNodeDriver):
         return self.__post_request(
                 "/my/machines/analytics/instrumentations".format(id), 
                 data)
-        return result.status == httplib.ACCEPTED
 
     def sc_del_instrumentation(self,id):
         return self.__delete_request('/my/machines/instrumentations/{0}'.format(node.id))

--- a/saltcloud/drivers/joyent.py
+++ b/saltcloud/drivers/joyent.py
@@ -94,21 +94,21 @@ class ExtendedJoyentNodeDriver(JoyentNodeDriver):
         return self.__delete_request('/my/machines/%s/tags' % (node.id))
 
     def sc_describe_analytics(self):
-        return self.__get_request('/my/machines/analytics')
+        return self.__get_request('/my/analytics')
 
     def sc_list_instrumenations(self):
-        return self.__get_request('/my/machines/analytics/instrumentations')
+        return self.__get_request('/my/analytics/instrumentations')
 
     def sc_get_instrumentation(self,id):
-        return self.__get_request("/my/machines/analytics/instrumentations/{0}".format(id))
+        return self.__get_request("/my/analytics/instrumentations/{0}".format(id))
 
     def sc_get_instrumentationValue(self,id):
         return self.__get_request(
-                "/my/machines/analytics/instrumentations/{0}/value/raw".format(id))
+                "/my/analytics/instrumentations/{0}/value/raw".format(id))
 
     def sc_get_instrumentationHeatmap(self,id):
         return self.__get_request(
-                "/my/machines/analytics/instrumentations/{0}/value/heatmap/image".format(id))
+                "/my/analytics/instrumentations/{0}/value/heatmap/image".format(id))
 
     def sc_get_instrumentationHeatmapDetails(self,id):
         return self.__get_request(
@@ -117,28 +117,28 @@ class ExtendedJoyentNodeDriver(JoyentNodeDriver):
     def sc_create_instrumentation(self,kvps):
         data = urllib.urlencode(kvps)
         return self.__post_request(
-                "/my/machines/analytics/instrumentations".format(id), 
+                "/my/analytics/instrumentations".format(id), 
                 data)
 
     def sc_del_instrumentation(self,id):
-        return self.__delete_request('/my/machines/instrumentations/{0}'.format(node.id))
+        return self.__delete_request('/my/analytics/instrumentations/{0}'.format(node.id))
 
     def sc_list_ssh_keys(self):
-        return self.__get_request("/my/machines/keys")
+        return self.__get_request("/my/keys")
 
     def sc_get_key(self,keyname):
-        return self.__get_request("/my/machines/%s" % keyname )
+        return self.__get_request("/my/keys/%s" % keyname )
 
     def sc_create_key(self,keyname,key):
         data = json.dumps({'name': keyname, 'key':key })
-        return self.__post_request("/my/machines/keys", data)
+        return self.__post_request("/my/keys", data)
 
     def sc_delete_key(self,keyname):
-        return self.__delete_request("/my/machines/keys/%s" % keyname)
+        return self.__delete_request("/my/keys/%s" % keyname)
 
     def sc_list_datacenters(self):
-        return self.__get_request("/my/machines/datacenters")
+        return self.__get_request("/my/datacenters")
 
     def sc_get_datacenter(self,dc):
-        return self.__get_request("/my/machines/datacenters/%s" % dc)
+        return self.__get_request("/my/datacenters/%s" % dc)
 

--- a/saltcloud/drivers/linode.py
+++ b/saltcloud/drivers/linode.py
@@ -1,0 +1,22 @@
+'''
+
+    libcloud rackspace driver exension
+
+'''
+# import libcloud common libraries/methods
+from saltcloud.libcloudfuncs import *
+
+# import rackspace sepcific driver classes
+from libcloud.compute.drivers.rackspace import (
+    LinodeNodeDriver
+    )
+
+
+class ExtendedLinodeNodeDriver(LinodeNodeDriver):
+    """
+    Extended rackspace node driver class.
+    """
+
+    def __init__(self,*args,**kwargs):
+        super(ExtendedLinodeNodeDriver,self).__init__(*args,**kwargs)
+

--- a/saltcloud/drivers/openstack.py
+++ b/saltcloud/drivers/openstack.py
@@ -1,0 +1,22 @@
+'''
+
+    libcloud openstack driver exension
+
+'''
+# import libcloud common libraries/methods
+from saltcloud.libcloudfuncs import *
+
+# import openstack sepcific driver classes
+from libcloud.compute.drivers.openstack import (
+    OpenStackNodeDriver
+    )
+
+
+class ExtendedOpenStackNodeDriver(OpenStackNodeDriver):
+    """
+    Extended openstack node driver class.
+    """
+
+    def __init__(self,*args,**kwargs):
+        super(ExtendedOpenstackNodeDriver,self).__init__(*args,**kwargs)
+

--- a/saltcloud/drivers/rackspace.py
+++ b/saltcloud/drivers/rackspace.py
@@ -1,0 +1,22 @@
+'''
+
+    libcloud rackspace driver exension
+
+'''
+# import libcloud common libraries/methods
+from saltcloud.libcloudfuncs import *
+
+# import rackspace sepcific driver classes
+from libcloud.compute.drivers.rackspace import (
+    RackspaceNodeDriver
+    )
+
+
+class ExtendedRackspaceNodeDriver(RackspaceNodeDriver):
+    """
+    Extended rackspace node driver class.
+    """
+
+    def __init__(self,*args,**kwargs):
+        super(ExtendedRackspaceNodeDriver,self).__init__(*args,**kwargs)
+

--- a/saltcloud/utils/parsers.py
+++ b/saltcloud/utils/parsers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: sw=4 ts=4 fenc=utf-8
 """
-    :copyright: © 2012 UfSoft.org - :email:`Pedro Algarvio (pedro@algarvio.me)`
+    :copyright: ÃÂÃÂ© 2012 UfSoft.org - :email:`Pedro Algarvio (pedro@algarvio.me)`
     :license: Apache 2.0, see LICENSE for more details
 """
 
@@ -278,7 +278,7 @@ class ExecutionOptionsMixIn(object):
 
     def process_function(self):
         if self.options.function:
-            self.function_provider, self.function_name = self.options.function
+            self.function_name , self.function_provider = self.options.function
             if self.function_name.startswith('-') or '=' in self.function_name:
                 self.error(
                     '--function expects two arguments: <provider> '

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ setup(name=NAME,
       packages=['saltcloud',
                 'saltcloud/utils',
                 'saltcloud/clouds',
+                'saltcloud/drivers',
                 ],
       package_data={
           'saltcloud': ['deploy/*.sh'],


### PR DESCRIPTION
Notice that in drivers/joyent.py , our methods can be called sc_start_node so that it does not clash with their base &lt;action&gt;_node or ex_&lt;action&gt;_node. However, as long as they are not private members, ours would naturally override their version of it.

I have tested the joyent code and all the base functions and the extended functions work perfectly.
