### PR TITLE
Deb dir fix

### DIFF
--- a/debian/salt-cloud.dirs
+++ b/debian/salt-cloud.dirs
@@ -1,1 +1,2 @@
 /etc/salt/cloud.conf.d/
+/etc/salt/cloud.profiles.d/

--- a/debian/salt-cloud.dirs
+++ b/debian/salt-cloud.dirs
@@ -1,1 +1,1 @@
-/etc/salt/cloud.d/
+/etc/salt/cloud.conf.d/


### PR DESCRIPTION
Pull request #457 forgot to update the /debian directory to reflect the changes to the packaging directory structure. This addresses that, and adds cloud.profiles.d which was previously forgotten completely.
- /etc/salt/cloud.d was renamed to /etc/salt/cloud.conf.d
- /etc/salt/cloud.profiles.d was added.
