### PR TITLE
import pprint required for openstack provider

### DIFF
--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -100,6 +100,7 @@ Using the new syntax:
 import time
 import logging
 import socket
+import pprint
 
 # Import libcloud
 from libcloud.compute.base import NodeState


### PR DESCRIPTION
I've been getting a bunch of these when trying to launch new OpenStack instances:

<pre>
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/saltcloud/clouds/openstack.py", line 362, in create
    pprint.pformat(
NameError: global name 'pprint' is not defined
</pre>


It seems the pprint module import line was missing.

<pre>
$ salt-cloud --versions
      Salt Cloud: 0.8.8
          Python: 2.7.3 (default, Jan  2 2013, 13:56:14)
            Salt: 0.14.0-604-g29efa17
 Apache Libcloud: 0.12.4
          PyYAML: 3.10
</pre>
