### PR TITLE
Fixed bug where minion name was indexing a string instead of a dict

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -838,9 +838,9 @@ class Map(Cloud):
                             tvm['map_minion'] = miniondict[name]['minion']
                         if 'volumes' in miniondict[name]:
                             tvm['map_volumes'] = miniondict[name]['volumes']
-                for myvar in miniondict[name]:
-                    if myvar not in ('grains', 'minion', 'volumes'):
-                        tvm[myvar] = miniondict[name][myvar]
+                    for myvar in miniondict[name]:
+                        if myvar not in ('grains', 'minion', 'volumes'):
+                            tvm[myvar] = miniondict[name][myvar]
             if 'minion' not in tvm:
                 tvm['minion'] = tvm['map_minion']
             if self.opts['parallel']:

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -838,9 +838,9 @@ class Map(Cloud):
                             tvm['map_minion'] = miniondict[name]['minion']
                         if 'volumes' in miniondict[name]:
                             tvm['map_volumes'] = miniondict[name]['volumes']
-                    for myvar in miniondict[name]:
-                        if myvar not in ('grains', 'minion', 'volumes'):
-                            tvm[myvar] = miniondict[name][myvar]
+                        for myvar in miniondict[name]:
+                            if myvar not in ('grains', 'minion', 'volumes'):
+                                tvm[myvar] = miniondict[name][myvar]
             if 'minion' not in tvm:
                 tvm['minion'] = tvm['map_minion']
             if self.opts['parallel']:


### PR DESCRIPTION
I found this bug when I tried to create a map to instantiate a set of nodes. The minion name was being used as an index when the variable miniondict was a string. I indented it to the correct level and salt-cloud was able to proceed to create the nodes based on the map definition.
