### PR TITLE
Log SSH/SCP commands

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -295,6 +295,8 @@ class SaltCloud(parsers.SaltCloudParser):
                 msg = 'There was a query error: {0}'
                 self.handle_exception(msg, exc)
 
+        else:
+            self.error('Nothing was done. Using the proper arguments?')
         # display output using salt's outputter system
         self.exit(0, '\n{0}'.format(self.display_output(ret)))
 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -772,9 +772,16 @@ def create(vm_=None, call=None):
 
         if waiting_for_ip >= 24:
             # 2 Minutes!? Bail out!
-            raise SaltCloudSystemExit(
-                'Could not get the VM IP for 2 minutes. Exiting.'
-            )
+            try:
+                # It might be already up, let's destroy it!
+                destroy(vm_['name'])
+            except SaltCloudSystemExit:
+                pass
+            finally:
+                raise SaltCloudSystemExit(
+                    'Could not get the VM IP for 2 minutes. Exiting.'
+                )
+
         waiting_for_ip += 1
 
     if ssh_interface(vm_) == 'private_ips':

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -819,6 +819,9 @@ def create(vm_=None, call=None):
             'display_ssh_output': config.get_config_value(
                 'display_ssh_output', vm_, __opts__, default=True
             ),
+            'stream_ssh_output'] = config.get_config_value(
+                'stream_ssh_output', vm_, __opts__, default=False
+            ),
             'minion_conf': saltcloud.utils.minion_conf_string(
                 __opts__, vm_
             ),

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -819,9 +819,6 @@ def create(vm_=None, call=None):
             'display_ssh_output': config.get_config_value(
                 'display_ssh_output', vm_, __opts__, default=True
             ),
-            'stream_ssh_output'] = config.get_config_value(
-                'stream_ssh_output', vm_, __opts__, default=False
-            ),
             'minion_conf': saltcloud.utils.minion_conf_string(
                 __opts__, vm_
             ),

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -358,7 +358,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
                             provider
                         )
                     )
-            elif len(providers.get(extends)) > 1:
+            elif providers.get(extends) and len(providers.get(extends)) > 1:
                 log.error(
                     'The {0!r} cloud provider entry in {1!r} is trying to '
                     'extend from {2!r} which has multiple entries and no '

--- a/saltcloud/deploy/bootstrap-salt.sh
+++ b/saltcloud/deploy/bootstrap-salt.sh
@@ -1214,26 +1214,26 @@ install_debian_6_deps() {
         echowarn "PyZMQ will be installed from PyPi in order to compile it against ZMQ3"
         echowarn "This is required for long term stable minion connections to the master."
 
-        if [ ! -f /etc/apt/sources.list.d/debian-experimental.list ]; then
-           cat <<_eof > /etc/apt/sources.list.d/debian-experimental.list
-deb http://ftp.debian.org/debian experimental main
-deb-src http://ftp.debian.org/debian experimental main
+        if [ ! -f /etc/apt/sources.list.d/debian-unstable.list ]; then
+           cat <<_eof > /etc/apt/sources.list.d/debian-unstable.list
+deb http://ftp.debian.org/debian unstable main
+deb-src http://ftp.debian.org/debian unstable main
 _eof
 
-           cat <<_eof > /etc/apt/preferences.d/libzmq3-debian-experimental.pref
+           cat <<_eof > /etc/apt/preferences.d/libzmq3-debian-unstable.pref
 Package: libzmq3
-Pin: release a=experimental
+Pin: release a=unstable
 Pin-Priority: 800
 
 Package: libzmq3-dev
-Pin: release a=experimental
+Pin: release a=unstable
 Pin-Priority: 800
 _eof
        fi
 
        apt-get update
 
-       __apt_get_noinput -t experimental libzmq3 libzmq3-dev || return 1
+       __apt_get_noinput -t unstable libzmq3 libzmq3-dev || return 1
        __apt_get_noinput build-essential python-dev python-pip || return 1
     else
         apt-get update
@@ -1254,26 +1254,26 @@ install_debian_7_deps() {
         echowarn "PyZMQ will be installed from PyPi in order to compile it against ZMQ3"
         echowarn "This is required for long term stable minion connections to the master."
 
-        if [ ! -f /etc/apt/sources.list.d/debian-experimental.list ]; then
-           cat <<_eof > /etc/apt/sources.list.d/debian-experimental.list
-deb http://ftp.debian.org/debian experimental main
-deb-src http://ftp.debian.org/debian experimental main
+        if [ ! -f /etc/apt/sources.list.d/debian-unstable.list ]; then
+           cat <<_eof > /etc/apt/sources.list.d/debian-unstable.list
+deb http://ftp.debian.org/debian unstable main
+deb-src http://ftp.debian.org/debian unstable main
 _eof
 
-           cat <<_eof > /etc/apt/preferences.d/libzmq3-debian-experimental.pref
+           cat <<_eof > /etc/apt/preferences.d/libzmq3-debian-unstable.pref
 Package: libzmq3
-Pin: release a=experimental
+Pin: release a=unstable
 Pin-Priority: 800
 
 Package: libzmq3-dev
-Pin: release a=experimental
+Pin: release a=unstable
 Pin-Priority: 800
 _eof
        fi
 
        apt-get update
 
-       __apt_get_noinput -t experimental libzmq3 libzmq3-dev || return 1
+       __apt_get_noinput -t unstable libzmq3 libzmq3-dev || return 1
        __apt_get_noinput build-essential python-dev python-pip || return 1
     else
         apt-get update
@@ -1294,7 +1294,7 @@ install_debian_git_deps() {
         echowarn "PyZMQ will be installed from PyPi in order to compile it against ZMQ3"
         echowarn "This is required for long term stable minion connections to the master."
 
-        __apt_get_noinput -t experimental libzmq3 libzmq3-dev || return 1
+        __apt_get_noinput -t unstable libzmq3 libzmq3-dev || return 1
         __apt_get_noinput build-essential python-dev python-pip || return 1
     fi
 
@@ -1316,7 +1316,7 @@ install_debian_6_git_deps() {
 }
 
 install_debian_7_git_deps() {
-    install_debian_7_deps || return 1    # Add experimental repository for ZMQ3
+    install_debian_7_deps || return 1    # Add unstable repository for ZMQ3
     install_debian_git_deps || return 1  # Grab the actual deps
     return 0
 }

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -28,6 +28,7 @@ import salt.utils.event
 
 # Import salt cloud libs
 import saltcloud.config as config
+from saltcloud.utils.nb_popen import NonBlockingPopen
 from saltcloud.exceptions import (
     SaltCloudConfigError,
     SaltCloudException,
@@ -368,8 +369,8 @@ def deploy_script(host, port=22, timeout=900, username='root',
                   master_pub=None, master_pem=None, master_conf=None,
                   minion_pub=None, minion_pem=None, minion_conf=None,
                   keep_tmp=False, script_args=None, ssh_timeout=15,
-                  display_ssh_output=True, make_syndic=False,
-                  preseed_minion_keys=None, make_minion=True):
+                  make_syndic=False, make_minion=True,
+                  display_ssh_output=True, preseed_minion_keys=None):
     '''
     Copy a deploy script to a remote server, execute it, and remove it
     '''
@@ -397,6 +398,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
                       'port': port,
                       'username': username,
                       'timeout': ssh_timeout,
+                      'stream_ssh_output': stream_ssh_output,
                       'display_ssh_output': display_ssh_output}
             if key_filename:
                 log.debug('Using {0} as the key_filename'.format(key_filename))
@@ -497,7 +499,6 @@ def deploy_script(host, port=22, timeout=900, username='root',
 
             # Run the deploy script
             if script:
-                log.debug('Executing /tmp/deploy.sh')
                 if 'bootstrap-salt' in script:
                     deploy_command += ' -c /tmp/'
                     if make_syndic is True:
@@ -697,24 +698,31 @@ def root_cmd(command, tty, sudo, **kwargs):
     if 'password' in kwargs:
         cmd = 'sshpass -p {0} {1}'.format(kwargs['password'], cmd)
 
-    log.debug('Executing command: {0}'.format(command))
-
-    display_ssh_output = kwargs.get('display_ssh_output', True)
-
-    if display_ssh_output is True:
-        proc = subprocess.Popen(cmd, shell=True)
-    else:
-        proc = subprocess.Popen(
-            cmd, shell=True,
+    try:
+        proc = NonBlockingPopen(
+            cmd,
+            shell=True,
             stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE
+            stdout=subprocess.PIPE,
+            stream_stds=kwargs.get('display_ssh_output', True),
         )
-    stdout, stderr = proc.communicate()
-    if display_ssh_output is not True and stdout:
-        log.debug('SSH Command STDOUT: {0}'.format(stdout))
-    if display_ssh_output is not True and stdout:
-        log.debug('SSH Command STDERR: {0}'.format(stderr))
-    return proc.returncode
+        log.debug(
+            'Executing command(PID {0}): {1!r}'.format(
+                proc.pid, command
+            )
+        )
+        while proc.poll() is None:
+            time.sleep(0.25)
+
+        proc.communicate()
+        return proc.returncode
+    except Exception as err:
+        log.error(
+            'Failed to execute command {0!r}: {1}\n'.format(
+                command, err
+            ),
+            exc_info=True
+        )
 
 
 def check_auth(name, pub_key=None, sock_dir=None, queue=None, timeout=300):

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -513,7 +513,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
                 if script_args:
                     deploy_command += ' {0}'.format(script_args)
 
-                if root_cmd(deploy_command, tty, sudo, **kwargs):
+                if root_cmd(deploy_command, tty, sudo, **kwargs) != 0:
                     raise SaltCloudSystemExit(
                         'Executing the command {0!r} failed'.format(
                             deploy_command

--- a/saltcloud/utils/nb_popen.py
+++ b/saltcloud/utils/nb_popen.py
@@ -18,71 +18,83 @@ import logging
 import subprocess
 
 
+log = logging.getLogger(__name__)
+
+
 class NonBlockingPopen(subprocess.Popen):
 
     def __init__(self, *args, **kwargs):
         self.stream_stds = kwargs.pop('stream_stds', False)
-        self.olog = logging.getLogger('{0}.stdout'.format(__name__))
-        self.elog = logging.getLogger('{0}.stderr'.format(__name__))
         super(NonBlockingPopen, self).__init__(*args, **kwargs)
-        if self.stdout is not None and self.stream_stds:
+
+        if self.stdout is not None:
             fod = self.stdout.fileno()
             fol = fcntl.fcntl(fod, fcntl.F_GETFL)
             fcntl.fcntl(fod, fcntl.F_SETFL, fol | os.O_NONBLOCK)
-            self.obuff = ''
+        self.obuff = ''
 
-        if self.stderr is not None and self.stream_stds:
+        if self.stderr is not None:
             fed = self.stderr.fileno()
             fel = fcntl.fcntl(fed, fcntl.F_GETFL)
             fcntl.fcntl(fed, fcntl.F_SETFL, fel | os.O_NONBLOCK)
-            self.ebuff = ''
+        self.ebuff = ''
+
+        log.info('Running command {0!r}'.format(*args))
 
     def poll(self):
         poll = super(NonBlockingPopen, self).poll()
 
-        if self.stdout is not None and self.stream_stds:
+        if self.stdout is not None:
             try:
                 obuff = self.stdout.read()
                 self.obuff += obuff
                 if obuff:
-                    self.olog.warn(obuff)
-                #sys.stdout.write(obuff)
+                    logging.getLogger(
+                        'saltcloud.Popen.STDOUT.PID-{0}'.format(self.pid)
+                    ).warn(obuff.rstrip())
+                    if self.stream_stds:
+                        sys.stdout.write(obuff)
             except IOError, err:
                 if err.errno not in (11, 35):
                     # We only handle Resource not ready properly, any other
                     # raise the exception
                     raise
-        if self.stderr is not None and self.stream_stds:
+
+        if self.stderr is not None:
             try:
                 ebuff = self.stderr.read()
                 self.ebuff += ebuff
                 if ebuff:
-                    self.elog.warn(ebuff)
-                #sys.stderr.write(ebuff)
+                    logging.getLogger(
+                        'saltcloud.Popen.STDERR.PID-{0}'.format(self.pid)
+                    ).warn(ebuff.rstrip())
+                    if self.stream_stds:
+                        sys.stderr.write(ebuff)
             except IOError, err:
                 if err.errno not in (11, 35):
                     # We only handle Resource not ready properly, any other
                     # raise the exception
                     raise
 
-        if poll is None:
-            # Not done yet
-            return poll
-
-        if not self.stream_stds:
-            # Allow the same attribute access even though not streaming to stds
-            try:
-                self.obuff = self.stdout.read()
-            except IOError, err:
-                if err.errno not in (11, 35):
-                    # We only handle Resource not ready properly, any other
-                    # raise the exception
-                    raise
-            try:
-                self.ebuff = self.stderr.read()
-            except IOError, err:
-                if err.errno not in (11, 35):
-                    # We only handle Resource not ready properly, any other
-                    # raise the exception
-                    raise
         return poll
+
+    def __del__(self):
+        if self.stdout is not None:
+            try:
+                fod = self.stdout.fileno()
+                fol = fcntl.fcntl(fod, fcntl.F_GETFL)
+                fcntl.fcntl(fod, fcntl.F_SETFL, fol & ~os.O_NONBLOCK)
+            except ValueError:
+                # Closed FD
+                pass
+
+        if self.stderr is not None:
+            try:
+                fed = self.stderr.fileno()
+                fel = fcntl.fcntl(fed, fcntl.F_GETFL)
+                fcntl.fcntl(fed, fcntl.F_SETFL, fel & ~os.O_NONBLOCK)
+            except ValueError:
+                # Closed FD
+                pass
+
+        super(NonBlockingPopen, self).__del__()

--- a/saltcloud/utils/nb_popen.py
+++ b/saltcloud/utils/nb_popen.py
@@ -51,7 +51,7 @@ class NonBlockingPopen(subprocess.Popen):
                 if obuff:
                     logging.getLogger(
                         'saltcloud.Popen.STDOUT.PID-{0}'.format(self.pid)
-                    ).warn(obuff.rstrip())
+                    ).debug(obuff.rstrip())
                     if self.stream_stds:
                         sys.stdout.write(obuff)
             except IOError, err:
@@ -67,7 +67,7 @@ class NonBlockingPopen(subprocess.Popen):
                 if ebuff:
                     logging.getLogger(
                         'saltcloud.Popen.STDERR.PID-{0}'.format(self.pid)
-                    ).warn(ebuff.rstrip())
+                    ).debug(ebuff.rstrip())
                     if self.stream_stds:
                         sys.stderr.write(ebuff)
             except IOError, err:

--- a/saltcloud/utils/nb_popen.py
+++ b/saltcloud/utils/nb_popen.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+'''
+    saltcloud.utils.nb_popen
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Non blocking subprocess Popen.
+
+    :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
+    :copyright: © 2013 by the SaltStack Team, see AUTHORS for more details.
+    :license: Apache 2.0, see LICENSE for more details.
+'''
+
+# Import python libs
+import os
+import sys
+import fcntl
+import subprocess
+
+
+class NonBlockingPopen(subprocess.Popen):
+
+    def __init__(self, *args, **kwargs):
+        self.stream_stds = kwargs.pop('stream_stds', False)
+        super(NonBlockingPopen, self).__init__(*args, **kwargs)
+        if self.stdout is not None and self.stream_stds:
+            fod = self.stdout.fileno()
+            fol = fcntl.fcntl(fod, fcntl.F_GETFL)
+            fcntl.fcntl(fod, fcntl.F_SETFL, fol | os.O_NONBLOCK)
+            self.obuff = ''
+
+        if self.stderr is not None and self.stream_stds:
+            fed = self.stderr.fileno()
+            fel = fcntl.fcntl(fed, fcntl.F_GETFL)
+            fcntl.fcntl(fed, fcntl.F_SETFL, fel | os.O_NONBLOCK)
+            self.ebuff = ''
+
+    def poll(self):
+        poll = super(NonBlockingPopen, self).poll()
+
+        if self.stdout is not None and self.stream_stds:
+            try:
+                obuff = self.stdout.read()
+                self.obuff += obuff
+                sys.stdout.write(obuff)
+            except IOError, err:
+                if err.errno not in (11, 35):
+                    # We only handle Resource not ready properly, any other
+                    # raise the exception
+                    raise
+        if self.stderr is not None and self.stream_stds:
+            try:
+                ebuff = self.stderr.read()
+                self.ebuff += ebuff
+                sys.stderr.write(ebuff)
+            except IOError, err:
+                if err.errno not in (11, 35):
+                    # We only handle Resource not ready properly, any other
+                    # raise the exception
+                    raise
+
+        if poll is None:
+            # Not done yet
+            return poll
+
+        if not self.stream_stds:
+            # Allow the same attribute access even though not streaming to stds
+            try:
+                self.obuff = self.stdout.read()
+            except IOError, err:
+                if err.errno not in (11, 35):
+                    # We only handle Resource not ready properly, any other
+                    # raise the exception
+                    raise
+            try:
+                self.ebuff = self.stderr.read()
+            except IOError, err:
+                if err.errno not in (11, 35):
+                    # We only handle Resource not ready properly, any other
+                    # raise the exception
+                    raise
+        return poll


### PR DESCRIPTION
All ssh/scp communications will be logged and we can automatically set `display_ssh_output` to False when running parallel deployments, and yet, still have all the ssh communication on the logs.
