### PR TITLE
Fix for #586

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -298,7 +298,8 @@ class SaltCloud(parsers.SaltCloudParser):
         else:
             self.error('Nothing was done. Using the proper arguments?')
         # display output using salt's outputter system
-        self.exit(0, '\n{0}'.format(self.display_output(ret)))
+        print(self.display_output(ret))
+        self.exit(0)
 
     def print_confirm(self, msg):
         if self.options.assume_yes:

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -648,6 +648,9 @@ class Cloud(object):
             for name in names:
                 if name in names_:
                     fun = '{0}.{1}'.format(prov, self.opts['action'])
+                    if fun not in self.clouds:
+                        # The cloud provider does not provide the action
+                        continue
                     if kwargs:
                         ret[name] = self.clouds[fun](
                             name, kwargs, call='action'


### PR DESCRIPTION
- Don't try to execute actions not provided by cloud provider.
- Regular and expected output should go to `stdout`, not `stderr`
