### PR TITLE
Handling of display_ssh_output in wait_for_passwd

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -818,12 +818,19 @@ def create(vm_=None, call=None):
         ip_address = data[0]['instancesSet']['item']['ipAddress']
         log.info('Salt node data. Public_ip: {0}'.format(ip_address))
 
+    display_ssh_output = config.get_config_value(
+        'display_ssh_output', vm_, __opts__, default=True
+    )
+
     if saltcloud.utils.wait_for_ssh(ip_address):
         for user in usernames:
-            if saltcloud.utils.wait_for_passwd(host=ip_address,
-                                               username=user,
-                                               ssh_timeout=60,
-                                               key_filename=key_filename):
+            if saltcloud.utils.wait_for_passwd(
+                host=ip_address,
+                username=user,
+                ssh_timeout=60,
+                key_filename=key_filename,
+                display_ssh_output=display_ssh_output
+            ):
                 username = user
                 break
         else:
@@ -852,9 +859,7 @@ def create(vm_=None, call=None):
             'minion_pub': vm_['pub_key'],
             'keep_tmp': __opts__['keep_tmp'],
             'preseed_minion_keys': vm_.get('preseed_minion_keys', None),
-            'display_ssh_output': config.get_config_value(
-                'display_ssh_output', vm_, __opts__, default=True
-            ),
+            'display_ssh_output': display_ssh_output,
             'minion_conf': saltcloud.utils.minion_conf_string(
                 __opts__, vm_
             ),

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -309,7 +309,7 @@ def wait_for_ssh(host, port=22, timeout=900):
 
 def wait_for_passwd(host, port=22, ssh_timeout=15, username='root',
                     password=None, key_filename=None, maxtries=15,
-                    trysleep=1):
+                    trysleep=1, display_ssh_output=True):
     '''
     Wait until ssh connection can be accessed via password or ssh key
     '''
@@ -320,7 +320,8 @@ def wait_for_passwd(host, port=22, ssh_timeout=15, username='root',
             kwargs = {'hostname': host,
                       'port': port,
                       'username': username,
-                      'timeout': ssh_timeout}
+                      'timeout': ssh_timeout,
+                      'display_ssh_output': display_ssh_output}
             if key_filename:
                 if not os.path.isfile(key_filename):
                     raise SaltCloudConfigError(
@@ -389,7 +390,8 @@ def deploy_script(host, port=22, timeout=900, username='root',
         newtimeout = timeout - (time.mktime(time.localtime()) - starttime)
         if wait_for_passwd(host, port=port, username=username,
                            password=password, key_filename=key_filename,
-                           ssh_timeout=ssh_timeout):
+                           ssh_timeout=ssh_timeout,
+                           display_ssh_output=display_ssh_output):
             log.debug(
                 'Logging into {0}:{1} as {2}'.format(
                     host, port, username


### PR DESCRIPTION
I run a script which wraps salt-cloud and uses the `-out json` option to action various minions after creation. Any garbage that's printed onto the terminal by salt-cloud obviously breaks this.

This patch prevents `wait_for_password` calling into `root_cmd` without `display_ssh_output` set.
