### PR TITLE
If there is no Name tag, just return instance id

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -1298,7 +1298,6 @@ def _extract_name_tag(item):
             for tag in tagset['item']:
                 if tag['key'] == 'Name':
                     return tag['value']
-        return (item['tagSet']['item']['value'])
     return item['instanceId']
 
 


### PR DESCRIPTION
If a vm has no name tag but has multiple tags, salt-cloud failed to return a name, which messed up being able to query correctly.
