### PR TITLE
Implement a simple types filter which `repr()`'s values

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -1131,7 +1131,9 @@ def create_multiprocessing(parallel_data):
     if parallel_data['opts'].get('show_deploy_args', False) is False:
         output.pop('deploy_kwargs', None)
 
-    return {parallel_data['name']: output}
+    return {
+        parallel_data['name']: saltcloud.utils.simple_types_filter(output)
+    }
 
 
 def run_paralel_map_providers_query(data):
@@ -1141,7 +1143,11 @@ def run_paralel_map_providers_query(data):
     '''
     cloud = Cloud(data['opts'])
     try:
-        return {data['provider']: cloud.clouds[data['fun']]()}
+        return {
+            data['provider']: saltcloud.utils.simple_types_filter(
+                cloud.clouds[data['fun']]()
+            )
+        }
     except Exception:
         # Failed to communicate with the provider, don't list any
         # nodes

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -947,3 +947,21 @@ def wait_for_ip(update_callback,
             )
         time.sleep(interval)
         timeout -= interval
+
+
+def simple_types_filter(datadict):
+    '''
+    Convert the data dictionary into simple types, ie, int, float, string,
+    bool, etc.
+    '''
+    simpletypes = (str, unicode, int, long, float, bool)
+    simpledict = {}
+    for key, value in datadict.iteritems():
+        if key is not None and not isinstance(key, simpletypes):
+            key = repr(key)
+        if isinstance(value, dict):
+            value = simple_types_filter(value)
+        elif value is not None and not isinstance(value, simpletypes):
+            value = repr(value)
+        simpledict[key] = value
+    return simpledict


### PR DESCRIPTION
Implement a simple types filter which `repr()`'s values not in `str`, `unicode`, `int`, `long`, `float`, `bool`, `None`. Fixes #612.
