### PR TITLE
Fix bug in wait_for_ip: ValueError: Unknown format code 'd' for object of type 'float'

### DIFF
--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -920,7 +920,7 @@ def wait_for_ip(update_callback,
         log.debug(
             'Waiting for VM IP. Giving up in 00:{0:02d}:{1:02d}'.format(
                 timeout // 60,
-                timeout % 60
+                int(timeout % 60)
             )
         )
         data = update_callback(*update_args, **update_kwargs)

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -942,7 +942,7 @@ def wait_for_ip(update_callback,
             raise SaltCloudExecutionTimeout(
                 'Unable to get IP for 00:{0:02d}:{1:02d}'.format(
                     duration // 60,
-                    duration % 60
+                    int(duration % 60)
                 )
             )
         time.sleep(interval)

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -919,7 +919,7 @@ def wait_for_ip(update_callback,
     while True:
         log.debug(
             'Waiting for VM IP. Giving up in 00:{0:02d}:{1:02d}'.format(
-                timeout // 60,
+                int(timeout // 60),
                 int(timeout % 60)
             )
         )
@@ -941,7 +941,7 @@ def wait_for_ip(update_callback,
         if timeout < 0:
             raise SaltCloudExecutionTimeout(
                 'Unable to get IP for 00:{0:02d}:{1:02d}'.format(
-                    duration // 60,
+                    int(duration // 60),
                     int(duration % 60)
                 )
             )


### PR DESCRIPTION
(timeout // 60)  is an integer even when timeout is a float.  But (timeout % 60) is a float when timeout is a float, so it cannot be formatted with "...{1:02d}...".format(...).
So I changed it to int(timeout % 60).

Same for duration % 60.
