### PR TITLE
Fix bug AttributeError: type object 'SaltCloudExecutionTimeout' has no a...

### DIFF
--- a/saltcloud/clouds/botocore_aws.py
+++ b/saltcloud/clouds/botocore_aws.py
@@ -125,19 +125,17 @@ def __virtual__():
         PRE_IMPORT_LOCALS_KEYS
     )
     for key in keysdiff:
-        if not callable(POST_IMPORT_LOCALS_KEYS[key]):
-            continue
-        # skip callables that might be exceptions
-        if any(['Error' in POST_IMPORT_LOCALS_KEYS[key].__name__,
-                'Exception' in POST_IMPORT_LOCALS_KEYS[key].__name__]):
-            continue
-        globals().update(
-            {
-                key: namespaced_function(
-                    POST_IMPORT_LOCALS_KEYS[key], globals(), ()
-                )
-            }
-        )
+        # only import callables that actually have __code__ (this includes
+        # functions but excludes Exception classes)
+        if (callable(POST_IMPORT_LOCALS_KEYS[key]) and
+            hasattr(POST_IMPORT_LOCALS_KEYS[key], "__code__")):
+            globals().update(
+                {
+                    key: namespaced_function(
+                        POST_IMPORT_LOCALS_KEYS[key], globals(), ()
+                    )
+                }
+            )
 
     global avail_images, avail_sizes, avail_locations, script
     global list_nodes, list_nodes_full, list_nodes_select


### PR DESCRIPTION
Fix bug AttributeError: type object 'SaltCloudExecutionTimeout' has no attribute '__code__'

The code in botocore_aws.py's __virtual__() function had a bug (see error message above).  This was due to the fact that the SaltCloudExecutionTimeout Exception class does not contain the words "Error" or "Exception" so it was not considered as an exception.  I started by adding the words "Timeout" and "Failure" to the list, but then I thought that this was not very robust code.  I suggest just checking that the object is a callable and that it has the __code__ attribute.
