### PR TITLE
Respect minion id if it's set in the profile.

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -529,7 +529,7 @@ class Cloud(object):
             vm_['pub_key'] = pub
             vm_['priv_key'] = priv
 
-        key_id = vm_['name']
+        key_id = minion_dict.get('id', vm_['name'])
 
         if 'append_domain' in minion_dict:
             key_id = '.'.join([key_id, minion_dict['append_domain']])


### PR DESCRIPTION
Default to vm_['name'] if it's not present.
Currently it's just defaulting to vm_['name'].
