### PR TITLE
Handle the case where a provider has no existing nodes available yet.

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -630,7 +630,9 @@ class Cloud(object):
         profile_details = self.opts['profiles'][profile]
         alias, driver = profile_details['provider'].split(':')
         mapped_providers = self.map_providers_parallel()
-        vms = mapped_providers[alias][driver]
+        alias_data = mapped_providers.setdefault(alias, {})
+        vms = alias_data.setdefault(driver, {})
+
         for name in names:
             if name in vms and vms[name]['state'].lower() != 'terminated':
                 msg = '{0} already exists under {0}:{1}'.format(


### PR DESCRIPTION
When launching a node on a provider with no existing nodes, this would previously fail with a KeyError as mapped_providers was assumed to always contain data: `mapped_providers[alias][driver]`. 

In the case where a provider has no existing nodes however, mapped_providers will be `{}`. This provide defaults in that case.
