### PR TITLE
Fixes issue #669

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -1298,7 +1298,7 @@ def _extract_name_tag(item):
             for tag in tagset['item']:
                 if tag['key'] == 'Name':
                     return tag['value']
-                return item['instanceId']
+            return item['instanceId']
         return (item['tagSet']['item']['value'])
     return item['instanceId']
 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -947,14 +947,17 @@ def create_attach_volumes(name, kwargs, call=None):
     ret = []
     for volume in volumes:
         volume_name = '{0} on {1}'.format(volume['device'], name)
-        created_volume = create_volume(
-            {
-                'size': volume['size'],
-                'volume_name': volume_name,
-                'zone': kwargs['zone']
-            },
-            call='function'
-        )
+
+        volume_dict = {
+            'volume_name': volume_name,
+            'zone': kwargs['zone']
+        }
+        if 'snapshot' in volume:
+            volume_dict['snapshot'] = volume['snapshot']
+        else:
+            volume_dict['size'] = volume['size']
+
+        created_volume = create_volume(volume_dict, call='function')
         for item in created_volume:
             if 'volumeId' in item:
                 volume_id = item['volumeId']


### PR DESCRIPTION
Allows snapshot to be provided in volume definitions so the snapshot may be used in create_attach_volume. If snapshot is not provided it defaults back to using the size attribute.
