### PR TITLE
Typo and make sure the salt cloud library is in `sys.path` when running the tests

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -16,10 +16,12 @@ import os
 import tempfile
 
 # Import salt testing libs
+from salttesting.helpers import ensure_in_syspath
 from salttesting.parser.cover import SaltCoverageTestingParser
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 SALTCLOUD_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+ensure_in_syspath(SALTCLOUD_ROOT)
 
 XML_OUTPUT_DIR = os.environ.get(
     'XML_TEST_REPORTS', os.path.join(

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -33,7 +33,7 @@ class CloudConfigTestCase(TestCase):
     def test_load_cloud_config_from_environ_var(self):
         if salt.version.__version_info__ < (0, 16, 0):
             self.skipTest(
-                'This test will always fail in salt >= 0.16.0 is not available'
+                'This test will always fail if salt >= 0.16.0 is not available'
             )
 
         original_environ = os.environ.copy()


### PR DESCRIPTION
Typo and make sure the salt cloud library is in `sys.path` when running the tests
