### PR TITLE
Dependencies in cloud map

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -979,14 +979,15 @@ class Map(Cloud):
         return False
 
     def _calcdep(self, dmap, machine, data, level):
-        level+=1
         try:
-            for name in data['requires']:
+            deplist = data['requires']
+            levels = []
+            for name in deplist:
                 data = dmap['create'][name]
-                level = self._calcdep(dmap, name, data, level)
+                levels.append(self._calcdep(dmap, name, data, level))
+            level = max(levels) + 1
             return level
         except KeyError:
-            level-=1
             return level
 
     def map_data(self, cached=False):

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -626,7 +626,7 @@ class Cloud(object):
             )
             client = salt.client.LocalClient()
             action_out = client.cmd(
-                vm_['name'], self.opts['start_action'], timeout=300
+                vm_['name'], self.opts['start_action'], timeout=self.opts['timeout'] * 60
             )
             output['ret']=action_out
         return output
@@ -1332,8 +1332,8 @@ class Map(Cloud):
                     )
                     client = salt.client.LocalClient()
                     out.update(client.cmd(
-                        ','.join(group), self.opts['start_action'], timeout=300,
-                        expr_form='list'
+                        ','.join(group), self.opts['start_action'],
+                        timeout=self.opts['timeout'] * 60, expr_form='list'
                     ))
             for obj in output_multip:
                 obj.values()[0]['ret'] = out[obj.keys()[0]] 

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -614,6 +614,8 @@ class Cloud(object):
                     vm_['name'], exc
                 )
             )
+        # If it's a map then we need to respect the 'requires'
+        # so we do it later
         if not self.opts['map']:
             if self.opts['parallel'] and self.opts['start_action']:
                 client = salt.client.LocalClient()
@@ -1289,6 +1291,8 @@ class Map(Cloud):
                 func=create_multiprocessing,
                 iterable=parallel_data
             )
+            # We have deployed in parallel, now do start action in
+            # correct order based on dependencies.
             if self.opts['start_action']:
                 action_list = [[]]
                 level = 0
@@ -1299,7 +1303,6 @@ class Map(Cloud):
                     action_list[new_level].append(item['name'])
                     level = new_level
                 for group in action_list:
-                    
                     client = salt.client.LocalClient()
                     output = client.cmd(
                         ','.join(group), self.opts['start_action'], timeout=300,

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -10,6 +10,7 @@ import signal
 import logging
 import multiprocessing
 import pprint
+from itertools import groupby
 
 # Import saltcloud libs
 import saltcloud.utils

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -9,6 +9,7 @@ import time
 import signal
 import logging
 import multiprocessing
+import pprint
 
 # Import saltcloud libs
 import saltcloud.utils
@@ -1281,6 +1282,23 @@ class Map(Cloud):
                 func=create_multiprocessing,
                 iterable=parallel_data
             )
+            if self.opts['start_action']:
+                action_list = [[]]
+                level = 0
+                for item in sorted(dmap['create'].values(), key=lambda x: x['level']):
+                    new_level = item['level']
+                    if new_level != level:
+                        action_list.append([])
+                    action_list[new_level].append(item['name'])
+                    level = new_level
+                for group in action_list:
+                    
+                    client = salt.client.LocalClient()
+                    output = client.cmd(
+                        ','.join(group), self.opts['start_action'], timeout=300,
+                        expr_form='list'
+                    )
+                    pprint.pprint(output)
             for obj in output_multip:
                 output.update(obj)
 

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -614,13 +614,13 @@ class Cloud(object):
                     vm_['name'], exc
                 )
             )
-
-        if self.opts['parallel'] and self.opts['start_action']:
-            client = salt.client.LocalClient()
-            out = client.cmd(
-                vm_['name'], self.opts['start_action'], timeout=300
-            )
-            pprint.pprint(out)
+        if not self.opts['map']:
+            if self.opts['parallel'] and self.opts['start_action']:
+                client = salt.client.LocalClient()
+                out = client.cmd(
+                    vm_['name'], self.opts['start_action'], timeout=300
+                )
+                pprint.pprint(out)
         return output
 
     def run_profile(self, profile, names):

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -615,6 +615,12 @@ class Cloud(object):
                 )
             )
 
+        if self.opts['parallel'] and self.opts['start_action']:
+            client = salt.client.LocalClient()
+            out = client.cmd(
+                vm_['name'], self.opts['start_action'], timeout=300
+            )
+            pprint.pprint(out)
         return output
 
     def run_profile(self, profile, names):

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -1313,7 +1313,7 @@ class Map(Cloud):
             # We have deployed in parallel, now do start action in
             # correct order based on dependencies.
             if self.opts['start_action']:
-                action_list = [[]]
+                actionlist = []
                 grp=-1
                 for k,v in groupby(dmap['create'].values(), lambda x: x['level']):
                     actionlist.append([]) 
@@ -1321,7 +1321,7 @@ class Map(Cloud):
                     for item in v:
                         actionlist[grp].append(item['name'])
                 pprint.pprint(actionlist)
-                for group in action_list:
+                for group in actionlist:
                     client = salt.client.LocalClient()
                     output = client.cmd(
                         ','.join(group), self.opts['start_action'], timeout=300,

--- a/saltcloud/clouds/cloudstack.py
+++ b/saltcloud/clouds/cloudstack.py
@@ -190,6 +190,7 @@ def create(vm_):
             'name': vm_['name'],
             'deploy_command': '/tmp/deploy.sh',
             'start_action': __opts__['start_action'],
+            'parallel': __opts__['parallel'],
             'sock_dir': __opts__['sock_dir'],
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],

--- a/saltcloud/clouds/digital_ocean.py
+++ b/saltcloud/clouds/digital_ocean.py
@@ -300,6 +300,7 @@ def create(vm_):
             'name': vm_['name'],
             'deploy_command': '/tmp/deploy.sh',
             'start_action': __opts__['start_action'],
+            'parallel': __opts__['parallel'],
             'sock_dir': __opts__['sock_dir'],
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -856,6 +856,7 @@ def create(vm_=None, call=None):
                 'sudo', vm_, __opts__, default=(username != 'root')
             ),
             'start_action': __opts__['start_action'],
+            'parallel': __opts__['parallel'],
             'conf_file': __opts__['conf_file'],
             'sock_dir': __opts__['sock_dir'],
             'minion_pem': vm_['priv_key'],

--- a/saltcloud/clouds/gogrid.py
+++ b/saltcloud/clouds/gogrid.py
@@ -150,6 +150,7 @@ def create(vm_):
             'script': deploy_script.script,
             'name': vm_['name'],
             'start_action': __opts__['start_action'],
+            'parallel': __opts__['parallel'],
             'sock_dir': __opts__['sock_dir'],
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],

--- a/saltcloud/clouds/ibmsce.py
+++ b/saltcloud/clouds/ibmsce.py
@@ -238,6 +238,7 @@ def create(vm_):
             'name': vm_['name'],
             'sudo': True,
             'start_action': __opts__['start_action'],
+            'parallel': __opts__['parallel'],
             'sock_dir': __opts__['sock_dir'],
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],

--- a/saltcloud/clouds/joyent.py
+++ b/saltcloud/clouds/joyent.py
@@ -272,6 +272,7 @@ def create(vm_):
             'deploy_command': '/tmp/deploy.sh',
             'tty': True,
             'start_action': __opts__['start_action'],
+            'parallel': __opts__['parallel'],
             'sock_dir': __opts__['sock_dir'],
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -414,6 +414,7 @@ def create(vm_):
                 'sudo', vm_, __opts__, default=(username != 'root')
             ),
             'start_action': __opts__['start_action'],
+            'parallel': __opts__['parallel'],
             'conf_file': __opts__['conf_file'],
             'sock_dir': __opts__['sock_dir'],
             'minion_pem': vm_['priv_key'],

--- a/saltcloud/clouds/linode.py
+++ b/saltcloud/clouds/linode.py
@@ -156,6 +156,7 @@ def create(vm_):
             'name': vm_['name'],
             'deploy_command': '/tmp/deploy.sh',
             'start_action': __opts__['start_action'],
+            'parallel': __opts__['parallel'],
             'sock_dir': __opts__['sock_dir'],
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -462,6 +462,7 @@ def create(vm_):
         'name': vm_['name'],
         'sock_dir': __opts__['sock_dir'],
         'start_action': __opts__['start_action'],
+        'parallel': __opts__['parallel'],
         'minion_pem': vm_['priv_key'],
         'minion_pub': vm_['pub_key'],
         'keep_tmp': __opts__['keep_tmp'],

--- a/saltcloud/clouds/parallels.py
+++ b/saltcloud/clouds/parallels.py
@@ -327,6 +327,7 @@ def create(vm_):
             'name': vm_['name'],
             'deploy_command': '/tmp/deploy.sh',
             'start_action': __opts__['start_action'],
+            'parallel': __opts__['parallel'],
             'sock_dir': __opts__['sock_dir'],
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],

--- a/saltcloud/clouds/rackspace.py
+++ b/saltcloud/clouds/rackspace.py
@@ -319,6 +319,7 @@ def create(vm_):
             'script': deploy_script.script,
             'name': vm_['name'],
             'start_action': __opts__['start_action'],
+            'parallel': __opts__['parallel'],
             'sock_dir': __opts__['sock_dir'],
             'conf_file': __opts__['conf_file'],
             'minion_pem': vm_['priv_key'],

--- a/saltcloud/clouds/saltify.py
+++ b/saltcloud/clouds/saltify.py
@@ -97,6 +97,7 @@ def create(vm_):
         'name': vm_['name'],
         'deploy_command': '/tmp/deploy.sh',
         'start_action': __opts__['start_action'],
+        'parallel': __opts__['parallel'],
         'sock_dir': __opts__['sock_dir'],
         'conf_file': __opts__['conf_file'],
         'minion_pem': vm_['priv_key'],

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -360,7 +360,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
                   minion_pub=None, minion_pem=None, minion_conf=None,
                   keep_tmp=False, script_args=None, script_env=None,
                   ssh_timeout=15, make_syndic=False, make_minion=True,
-                  display_ssh_output=True, preseed_minion_keys=None):
+                  display_ssh_output=True, preseed_minion_keys=None, parallel=False):
     '''
     Copy a deploy script to a remote server, execute it, and remove it
     '''
@@ -514,7 +514,8 @@ def deploy_script(host, port=22, timeout=900, username='root',
             process = None
             # Consider this code experimental. It causes Salt Cloud to wait
             # for the minion to check in, and then fire a startup event.
-            if start_action:
+            # Disabled if parallel because it doesn't work!
+            if start_action and not parallel:
                 queue = multiprocessing.Queue()
                 process = multiprocessing.Process(
                     target=check_auth, kwargs=dict(
@@ -637,7 +638,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
                         'Removed {0}'.format(preseed_minion_keys_tempdir)
                     )
 
-            if start_action:
+            if start_action and not parallel:
                 queuereturn = queue.get()
                 process.join()
                 if queuereturn and start_action:


### PR DESCRIPTION
Hi All,

Here's what I've been working on as part of the salt sprint.

I wanted to be able to make machines dependent on each other in a cloud map so that they get deployed in a specific order.

So you can do something like:

```
ubuntu_small:
    - web01:
        requires:
            - db01
    - web02:
        requires:
            - db01
    - db01
    - loadbalancer:
        requires:
            - web01
            - web02
```

This is straightforward for non parallel deployments because I can just order the list before we deploy. However it is more tricky in parallel. I found that adding a start_action for parallel deployments wasn't working at all so with these changes the start actions get triggered after all the machines have been deployed (but respecting the dependencies). So the machines are all created at the same time but the start actions run in the correct way afterwards.

I'd welcome some feedback/debate on whether this is the best way of doing it? Also on formatting the start_action output?

Thanks,
Matt
