### PR TITLE
Fix bug in cli argument parsing

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -252,7 +252,7 @@ class SaltCloud(parsers.SaltCloudParser):
         elif self.options.function:
             kwargs = {}
             args = self.args[:]
-            for arg in args:
+            for arg in args[:]:
                 if '=' in arg:
                     key, value = arg.split('=')
                     kwargs[key] = value


### PR DESCRIPTION
The argument list was being manipulated inside the for loop.
This was causing the loop to behave very strangely on some systems.
The loop would exit after the first iteration and the command would
exit with an error
