### PR TITLE
added libtool emerge in gentoo bootstrap

### DIFF
--- a/saltcloud/deploy/bootstrap-salt.sh
+++ b/saltcloud/deploy/bootstrap-salt.sh
@@ -2683,6 +2683,8 @@ __gentoo_post_dep() {
     cat >> ${GENTOO_ACKEYS} << _EOT
 # End of bootstrap-salt keywords.
 _EOT
+    # emerge libtool in case it is out of date, fixes compilation issues with crypto++
+    emerge libtool
     # the -o option asks it to emerge the deps but not the package.
     emerge ${__gentoo_use_binhost} -vo salt
 }


### PR DESCRIPTION
This fixes compilation issues with crypto++ on rackspace cloud servers
