### PR TITLE
add tag support at instance creation to ec2 and aws providers. fixes #674

### DIFF
--- a/doc/topics/aws.rst
+++ b/doc/topics/aws.rst
@@ -298,6 +298,16 @@ each cloud profile.
           VirtualName: ephemeral1
 
 
+Tags can be set once an instance has been launched.
+
+.. code.block:: yaml
+
+    my-ec2-config:
+        tag:
+            tag0: value
+            tag2: value
+
+
 Modify EC2 Tags
 ===============
 One of the features of EC2 is the ability to tag resources. In fact, under the 

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -718,6 +718,14 @@ def create(vm_=None, call=None):
             set_delvol_on_destroy
         ).lower()
 
+    tags = config.get_config_value('tag', vm_, __opts__, {}, search_global=False)
+    if not isinstance(tags, dict):
+        raise SaltCloudConfigError(
+                '\'tag\' should be a dict.'
+            )
+
+    tags['Name'] = vm_['name']
+
     try:
         data = query(params, 'instancesSet', location=location)
         if 'error' in data:
@@ -809,7 +817,7 @@ def create(vm_=None, call=None):
             raise SaltCloudSystemExit(exc.message)
 
     set_tags(
-        vm_['name'], {'Name': vm_['name']},
+        vm_['name'], tags,
         instance_id=instance_id, call='action', location=location
     )
     log.info('Created node {0}'.format(vm_['name']))

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -333,6 +333,11 @@ def create(vm_):
     ex_blockdevicemappings = block_device_mappings(vm_)
     if ex_blockdevicemappings:
         kwargs['ex_blockdevicemappings'] = ex_blockdevicemappings
+    tags = config.get_config_value('tag', vm_, __opts__, {}, search_global=False)
+    if not isinstance(tags, dict):
+        raise SaltCloudConfigError(
+                '\'tag\' should be a dict.'
+            )
 
     try:
         data = conn.create_node(**kwargs)
@@ -377,6 +382,9 @@ def create(vm_):
             pass
         finally:
             raise SaltCloudSystemExit(exc.message)
+
+    if tags:
+        set_tags(vm_['name'], tags, call='action')
 
     if ssh_interface(vm_) == 'private_ips':
         log.info('Salt node data. Private_ip: {0}'.format(data.private_ips[0]))


### PR DESCRIPTION
#674 will have to be completed per cloud provider driver depending on if they support tags.
