### PR TITLE
Prevent exception when using -P without a start_action

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -1354,9 +1354,11 @@ class Map(Cloud):
                         ','.join(group), self.opts['start_action'],
                         timeout=self.opts['timeout'] * 60, expr_form='list'
                     ))
-            for obj in output_multip:
-                obj.values()[0]['ret'] = out[obj.keys()[0]]
-                output.update(obj)
+                for obj in output_multip:
+                    obj.values()[0]['ret'] = out[obj.keys()[0]]
+                    output.update(obj)
+            else:
+                output = output_multip
 
         return output
 


### PR DESCRIPTION
I had an error where `out` was never initialized if there was no `start_action` set. (Possibly `start_action` should always be initialized?! I'm not sure of its purpose.)
