### PR TITLE
Fix for #744 and some improvements

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -1251,6 +1251,12 @@ class Map(Cloud):
                     )
                 )
 
+            elif 'Errors' in out:
+                raise SaltCloudSystemExit(
+                    'An error occurred while creating the master, not '
+                    'continuing: {0}'.format(out['Errors'])
+                )
+
             deploy_kwargs = (
                 self.opts.get('show_deploy_args', False) is True and
                 # Get the needed data

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -624,13 +624,17 @@ class Cloud(object):
             opt_map = False
         if self.opts['parallel'] and self.opts['start_action'] and not opt_map:
             log.info(
-                "Running {0} on {1}".format(self.opts['start_action'], vm_['name'])
+                'Running {0} on {1}'.format(
+                    self.opts['start_action'], vm_['name']
+                )
             )
             client = salt.client.LocalClient()
             action_out = client.cmd(
-                vm_['name'], self.opts['start_action'], timeout=self.opts['timeout'] * 60
+                vm_['name'],
+                self.opts['start_action'],
+                timeout=self.opts['timeout'] * 60
             )
-            output['ret']=action_out
+            output['ret'] = action_out
         return output
 
     def run_profile(self, profile, names):
@@ -931,7 +935,9 @@ class Map(Cloud):
             return {}
 
         if 'include' in map_:
-            map_ = salt.config.include_config(map_, self.opts['map'])
+            map_ = salt.config.include_config(
+                map_, self.opts['map'], verbose=False
+            )
 
         # Create expected data format if needed
         for profile, mapped in map_.copy().items():
@@ -982,11 +988,11 @@ class Map(Cloud):
 
     def _has_loop(self, dmap, seen=None, val=None):
         if seen is None:
-            for k,v in dmap['create'].items():
+            for values in dmap['create'].values():
                 seen = []
                 try:
-                    machines = v['requires']
-                except KeyError as e:
+                    machines = values['requires']
+                except KeyError:
                     machines = []
                 for machine in machines:
                     if self._has_loop(dmap, seen=list(seen), val=machine):
@@ -994,15 +1000,16 @@ class Map(Cloud):
         else:
             if val in seen:
                 return True
-            else:
-                seen.append(val)
-                try:
-                    machines = dmap['create'][val]['requires']
-                except KeyError as e:
-                    machines = []
-                for machine in machines:
-                    if self._has_loop(dmap, seen=list(seen), val=machine):
-                        return True
+
+            seen.append(val)
+            try:
+                machines = dmap['create'][val]['requires']
+            except KeyError:
+                machines = []
+
+            for machine in machines:
+                if self._has_loop(dmap, seen=list(seen), val=machine):
+                    return True
         return False
 
     def _calcdep(self, dmap, machine, data, level):
@@ -1054,7 +1061,8 @@ class Map(Cloud):
                 # Get the VM name
                 nodedata = profile_data.copy()
                 # Update profile data with the map overrides
-                for setting in ('grains', 'master', 'minion', 'volumes', 'requires'):
+                for setting in ('grains', 'master', 'minion', 'volumes',
+                                'requires'):
                     deprecated = 'map_{0}'.format(setting)
                     if deprecated in overrides:
                         log.warn(
@@ -1159,24 +1167,28 @@ class Map(Cloud):
             log.error(msg)
             raise SaltCloudException(msg)
         #Go through the create list and calc dependencies
-        for k,v in dmap['create'].items():
-            log.info("Calculating dependencies for {0}".format(k))
+        for key, val in dmap['create'].items():
+            log.info('Calculating dependencies for {0}'.format(key))
             level = 0
-            level = self._calcdep(dmap, k, v, level)
-            log.debug("Got execution order {0} for {1}".format(level,k))
-            dmap['create'][k]['level'] = level
+            level = self._calcdep(dmap, key, val, level)
+            log.debug('Got execution order {0} for {1}'.format(level, key))
+            dmap['create'][key]['level'] = level
+
         try:
             existing_list = dmap['existing'].items()
         except KeyError:
-            existing_list={}
-        for k,v in existing_list:
-            log.info("Calculating dependencies for {0}".format(k))
+            existing_list = {}
+
+        for key, val in existing_list:
+            log.info('Calculating dependencies for {0}'.format(key))
             level = 0
-            level = self._calcdep(dmap, k, v, level)
-            log.debug("Got execution order {0} for {1}".format(level,k))
-            dmap['existing'][k]['level'] = level
+            level = self._calcdep(dmap, key, val, level)
+            log.debug('Got execution order {0} for {1}'.format(level, key))
+            dmap['existing'][key]['level'] = level
+
         #Now sort the create list based on dependencies
-        create_list = sorted(dmap['create'].items(), key=lambda x: x[1]['level'])
+        create_list = sorted(dmap['create'].items(),
+                             key=lambda x: x[1]['level'])
         output = {}
         if self.opts['parallel']:
             parallel_data = []
@@ -1344,16 +1356,20 @@ class Map(Cloud):
             # correct order based on dependencies.
             if self.opts['start_action']:
                 actionlist = []
-                grp=-1
-                for k,v in groupby(dmap['create'].values(), lambda x: x['level']):
+                grp = -1
+                for key, val in groupby(dmap['create'].values(),
+                                        lambda x: x['level']):
                     actionlist.append([])
-                    grp +=1
-                    for item in v:
+                    grp += 1
+                    for item in val:
                         actionlist[grp].append(item['name'])
-                out={}
+
+                out = {}
                 for group in actionlist:
                     log.info(
-                        "Running {0} on {1}".format(self.opts['start_action'], ', '.join(group))
+                        'Running {0} on {1}'.format(
+                            self.opts['start_action'], ', '.join(group)
+                        )
                     )
                     client = salt.client.LocalClient()
                     out.update(client.cmd(

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -6,6 +6,7 @@ Manage configuration files in salt-cloud
 import os
 import glob
 import logging
+from copy import deepcopy
 
 # Import salt libs
 import salt.config
@@ -720,7 +721,7 @@ def get_config_value(name, vm_, opts, default=None, search_global=True):
 
     if search_global is True and opts.get(name, None) is not None:
         # The setting name exists in the cloud(global) configuration
-        value = opts[name]
+        value = deepcopy(opts[name])
 
     if vm_ and name:
         if ':' in vm_['provider']:
@@ -733,7 +734,7 @@ def get_config_value(name, vm_, opts, default=None, search_global=True):
                     if isinstance(value, dict):
                         value.update(details[name].copy())
                     else:
-                        value = details[name]
+                        value = deepcopy(details[name])
         elif len(opts['providers'].get(vm_['provider'], ())) > 1:
             # The provider is NOT defined as <provider-alias>:<provider-name>
             # and there's more than one entry under the alias.
@@ -758,14 +759,14 @@ def get_config_value(name, vm_, opts, default=None, search_global=True):
                 if isinstance(value, dict):
                     value.update(provider_driver_defs[name].copy())
                 else:
-                    value = provider_driver_defs[name]
+                    value = deepcopy(provider_driver_defs[name])
 
     if name and vm_ and name in vm_:
         # The setting name exists in VM configuration.
         if isinstance(value, dict):
-            value.update(vm_[name])
+            value.update(vm_[name].copy())
         else:
-            value = vm_[name]
+            value = deepcopy(vm_[name])
 
     return value
 

--- a/saltcloud/config.py
+++ b/saltcloud/config.py
@@ -711,11 +711,13 @@ def get_config_value(name, vm_, opts, default=None, search_global=True):
     '''
     Search and return a setting in a known order:
 
-        1. In the virtual machines configuration
-        2. In the virtual machine's provider configuration
-        3. In the salt cloud configuration if global searching is enabled
-        4. Return the provided default
+        1. In the virtual machine's configuration
+        2. In the virtual machine's profile configuration
+        3. In the virtual machine's provider configuration
+        4. In the salt cloud configuration if global searching is enabled
+        5. Return the provided default
     '''
+
     # As a last resort, return the default
     value = default
 
@@ -724,6 +726,14 @@ def get_config_value(name, vm_, opts, default=None, search_global=True):
         value = deepcopy(opts[name])
 
     if vm_ and name:
+        # Let's get the value from the profile, if present
+        if 'profile' in vm_ and name in opts['profiles'][vm_['profile']]:
+            if isinstance(value, dict):
+                value.update(opts['profiles'][vm_['profile']][name].copy())
+            else:
+                value = deepcopy(opts['profiles'][vm_['profile']][name])
+
+        # Let's get the value from the provider, if present
         if ':' in vm_['provider']:
             # The provider is defined as <provider-alias>:<provider-name>
             alias, driver = vm_['provider'].split(':')

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -442,8 +442,7 @@ def deploy_script(host, port=22, timeout=900, username='root',
                 root_cmd('service sshd restart', tty, sudo, **kwargs)
 
             # Update hostname on the minion
-            hostname_cmd = 'test `hostname` == {0} || hostname {0}'.format(name)
-            root_cmd(hostname_cmd, tty, sudo, **kwargs)
+            root_cmd('test `hostname` == {0} || hostname {0}'.format(name))
 
             # Minion configuration
             if minion_pem:

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -441,9 +441,6 @@ def deploy_script(host, port=22, timeout=900, username='root',
                 root_cmd(subsys_command, tty, sudo, **kwargs)
                 root_cmd('service sshd restart', tty, sudo, **kwargs)
 
-            # Update hostname on the minion
-            root_cmd('test `hostname` == {0} || hostname {0}'.format(name))
-
             # Minion configuration
             if minion_pem:
                 scp_file('/tmp/minion.pem', minion_pem, kwargs)


### PR DESCRIPTION
- If the master failed to create, do not continue with the map.
- When search for configuration keys on the VM's configuration or it's provider or the global config, don't forget that VM's profile configuration. When bootstrapping VMs using the profile this extra step is not necessary, though, when bootstrapping using maps, the map only holds the profile name, not it's data, making this extra step, fundamental.
