### PR TITLE
Move 'Running command...' from info to debug message

### DIFF
--- a/saltcloud/utils/nb_popen.py
+++ b/saltcloud/utils/nb_popen.py
@@ -73,7 +73,7 @@ class CloudNonBlockingPopen(subprocess.Popen):
         self._stderr_logger = logging.getLogger(
             self._stderr_logger_name_.format(pid=self.pid)
         )
-        log.info(
+        log.debug(
             'Running command under pid {0}: {1!r}'.format(self.pid, *args)
         )
 


### PR DESCRIPTION
The follow output has been moved to a debug message now, since its more
for developers to debug:

[INFO    ] Running command under pid 24591: 'ssh
-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null
-oControlPath=none -oPasswordAuthentication=no
-oChallengeResponseAuthentication=no -oPubkeyAuthentication=yes
-oKbdInteractiveAuthentication=no -i /home/pabelanger/.ssh/id_rsa.pub
ubuntu@172.16.100.2 date'

Signed-off-by: Paul Belanger paul.belanger@polybeacon.com
