### PR TITLE
Fixing list index error for some AMIs

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -848,7 +848,10 @@ def create(vm_=None, call=None):
 
         # pull the root device name from the result and use it when
         # launching the new VM
-        rd_name = rd_data[0]['blockDeviceMapping']['item'][0]['deviceName']
+        if type(rd_data[0]['blockDeviceMapping']['item']) is list:
+            rd_name = rd_data[0]['blockDeviceMapping']['item'][0]['deviceName']
+        else:
+            rd_name = rd_data[0]['blockDeviceMapping']['item']['deviceName']
         log.info('Found root device name: {0}'.format(rd_name))
 
         params[spot_prefix+'BlockDeviceMapping.1.DeviceName'] = rd_name


### PR DESCRIPTION
The data returned in rd_data[0]['blockDeviceMapping']['item'] is sometimes a string (such as in ami-642bba0d, a CentOS image) and sometimes a list (such as in ami-10314d79, an Ubuntu image). Handle it appropriately.
