### PR TITLE
Added verify_ssl_cert and networkid options

### DIFF
--- a/saltcloud/clouds/cloudstack.py
+++ b/saltcloud/clouds/cloudstack.py
@@ -27,6 +27,8 @@ import logging
 import saltcloud.config as config
 from saltcloud.libcloudfuncs import *   # pylint: disable-msg=W0614,W0401
 from saltcloud.utils import namespaced_function
+# CloudStackNetwork will be needed during creation of a new node
+from libcloud.compute.drivers.cloudstack import CloudStackNetwork
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -52,6 +54,20 @@ def __virtual__():
     if get_configured_provider() is False:
         log.debug(
             'There is no CloudStack cloud provider configuration available. '
+            'Not loading module.'
+        )
+        return False
+
+    verify_ssl_cert = config.get_config_value(
+            'verify_ssl_cert', get_configured_provider(), __opts__, default=True, search_global=False
+        )
+    if not verify_ssl_cert:
+      try:
+        import libcloud.security
+        libcloud.security.VERIFY_SSL_CERT = False
+      except:
+        log.debug(
+            'Could not disable SSL certificate verification. '
             'Not loading module.'
         )
         return False
@@ -150,6 +166,14 @@ def get_ip(data):
         ip = data.private_ips[0]
     return ip
 
+def get_networkid(conn, vm_):
+    '''
+    Return the networkid to use
+    '''
+    networkid = config.get_config_value('networkid', vm_, __opts__)
+    if networkid is not None:
+        return networkid
+    raise SaltCloudNotFound('The specified networkid could not be found.')
 
 def create(vm_):
     '''
@@ -163,6 +187,8 @@ def create(vm_):
         'size': get_size(conn, vm_),
         'location': get_location(conn, vm_),
         'keypair': get_keypair(vm_),
+        'networks': ( CloudStackNetwork( None, None, None, get_networkid(conn, vm_), None, None ), ), # The only attr that is used is 'id'. Setting the rest to None
+        'password': [],
     }
     try:
         data = conn.create_node(**kwargs)
@@ -185,6 +211,7 @@ def create(vm_):
         deploy_kwargs = {
             'host': get_ip(data),
             'username': 'root',
+            'password': data.extra['password'],
             'key_filename': get_key(),
             'script': deploy_script.script,
             'name': vm_['name'],


### PR DESCRIPTION
verify_ssl_cert can be used to disabled SSL certificate verification, which
is useful in case a self-signed certificate is used on CloudStack server.
networkid can be used to launch the server into a specific network.
Also it uses extra['password'] that is provided by latest version of libcloud.

As a result, I get to have cloud.providers and cloud.profiles files like the following:
cloud.providers 

```
mycloud:
  apikey: "Some Key"
  secretkey: "Some Key"
  host: "cloud.ops.dot"
  path: "/client/api"
  provider: cloudstack
  verify_ssl_cert: false
```

cloud.profiles

```
small:
    provider: mycloud
    image: CentOS 6 minimal
    size: Small Instance
    location: YUL01
    ssh_interface: public
    keypair: mycloud
    networkid: ab815684-880b-4c45-91ce-8e8041d15e63
```
