### PR TITLE
Adds Rackconnect support, refs Issue #199

### DIFF
--- a/doc/topics/rackspace.rst
+++ b/doc/topics/rackspace.rst
@@ -130,12 +130,12 @@ it can be verified with Salt:
 RackConnect Environments
 --------------------------------
 
-Rackspace offered a hybrid hosting configuration option called RackConnect that
+Rackspace offers a hybrid hosting configuration option called RackConnect that
 allows you to use a physical firewall appliance with your cloud servers. When this 
 service is in use the public_ip assigned by nova will be replaced by a NAT ip on
 the firewall. For salt-cloud to work properly it must use the newly assigned "access ip"
 instead of the Nova assigned public ip. You can enable that capability by adding this 
-to you profiles:
+to your profiles:
 
 .. code-block:: yaml
 

--- a/doc/topics/rackspace.rst
+++ b/doc/topics/rackspace.rst
@@ -127,6 +127,23 @@ it can be verified with Salt:
 
     # salt myinstance test.ping
 
+RackConnect Environments
+--------------------------------
+
+Rackspace offered a hybrid hosting configuration option called RackConnect that
+allows you to use a physical firewall appliance with your cloud servers. When this 
+service is in use the public_ip assigned by nova will be replaced by a NAT ip on
+the firewall. For salt-cloud to work properly it must use the newly assigned "access ip"
+instead of the Nova assigned public ip. You can enable that capability by adding this 
+to you profiles:
+
+.. code-block:: yaml
+
+    openstack_512:
+        provider: my-openstack-config
+        size: 512MB Standard Instance
+        image: Ubuntu 12.04 LTS (Precise Pangolin)
+        rackconnect: True
 
 First and Next Generation Images
 --------------------------------

--- a/saltcloud/libcloudfuncs.py
+++ b/saltcloud/libcloudfuncs.py
@@ -70,6 +70,7 @@ def get_node(conn, name):
     Return a libcloud node for the named VM
     '''
     nodes = conn.list_nodes()
+    print nodes
     for node in nodes:
         if node.name == name:
             return node
@@ -368,6 +369,7 @@ def list_nodes(conn=None):
             'private_ips': node.private_ips,
             'public_ips': node.public_ips,
             'size': node.size,
+            'extra': node.extra,
             'state': node_state(node.state)
         }
     return ret

--- a/saltcloud/libcloudfuncs.py
+++ b/saltcloud/libcloudfuncs.py
@@ -70,7 +70,6 @@ def get_node(conn, name):
     Return a libcloud node for the named VM
     '''
     nodes = conn.list_nodes()
-    print nodes
     for node in nodes:
         if node.name == name:
             return node


### PR DESCRIPTION
This patch depends on a change committed to libcloud that exposes the accessIPv4 argument in the Openstack driver. 

https://github.com/apache/libcloud/commit/12b830889283ede2acf0d8a4ea874e755df33c9e

Merged with trunk and should be released with libcloud 0.14.0. 
