### PR TITLE
Add show_delvol_on_destroy and other bug fixes

### DIFF
--- a/doc/topics/aws.rst
+++ b/doc/topics/aws.rst
@@ -485,6 +485,7 @@ using one of the following commands:
 
     salt-cloud -a delvol_on_destroy myinstance
     salt-cloud -a keepvol_on_destroy myinstance
+    salt-cloud -a show_delvol_on_destroy myinstance
 
 The setting for this may be changed on a volume on an existing instance
 using one of the following commands:
@@ -495,6 +496,8 @@ using one of the following commands:
     salt-cloud -a delvol_on_destroy myinstance volume_id=vol-1a2b3c4d
     salt-cloud -a keepvol_on_destroy myinstance device=/dev/sda1
     salt-cloud -a keepvol_on_destroy myinstance volume_id=vol-1a2b3c4d
+    salt-cloud -a show_delvol_on_destroy myinstance device=/dev/sda1
+    salt-cloud -a show_delvol_on_destroy myinstance volume_id=vol-1a2b3c4d
 
 
 EC2 Termination Protection

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -1252,6 +1252,7 @@ def create_attach_volumes(name, kwargs, call=None):
 
     ret = []
     for volume in volumes:
+        created = False
         volume_name = '{0} on {1}'.format(volume['device'], name)
 
         volume_dict = {
@@ -1272,16 +1273,10 @@ def create_attach_volumes(name, kwargs, call=None):
 
         if 'volume_id' not in volume_dict:
             created_volume = create_volume(volume_dict, call='function')
+            created = True
             for item in created_volume:
                 if 'volumeId' in item:
                     volume_dict['volume_id'] = item['volumeId']
-
-            # Update the delvol parameter for any newly created volumes
-            delvols_on_destroy = kwargs.get('del_all_vols_on_destroy', None)
-
-            if delvols_on_destroy is not None:
-                _toggle_delvol(instance_id=kwargs['instance_id'],
-                               value=delvols_on_destroy)
 
         attach = attach_volume(
             name,
@@ -1289,6 +1284,15 @@ def create_attach_volumes(name, kwargs, call=None):
             instance_id=kwargs['instance_id'],
             call='action'
         )
+
+        # Update the delvol parameter for this volume
+        delvols_on_destroy = kwargs.get('del_all_vols_on_destroy', None)
+
+        if attach and created and delvols_on_destroy is not None:
+            _toggle_delvol(instance_id=kwargs['instance_id'],
+                           device=volume['device'],
+                           value=delvols_on_destroy)
+
         if attach:
             msg = (
                 '{0} attached to {1} (aka {2}) as device {3}'.format(
@@ -1837,7 +1841,64 @@ def _toggle_term_protect(name, value):
     return show_term_protect(name=name, instance_id=instance_id, call='action')
 
 
-def keepvol_on_destroy(name, device=None, volume_id=None, call=None):
+def show_delvol_on_destroy(name, kwargs=None, call=None):
+    '''
+    Do not delete all/specified EBS volumes upon instance termination
+
+    CLI Example::
+
+        salt-cloud -a show_delvol_on_destroy mymachine
+    '''
+
+    if call != 'action':
+        raise SaltCloudSystemExit(
+            'The keepvol_on_destroy action must be called with -a or --action.'
+        )
+
+    if not kwargs:
+        kwargs = {}
+
+    instance_id = kwargs.get('instance_id', None)
+    device = kwargs.get('device', None)
+    volume_id = kwargs.get('volume_id', None)
+
+    if instance_id is None:
+        instances = list_nodes_full()
+        instance_id = instances[name]['instanceId']
+
+    params = {'Action': 'DescribeInstances',
+              'InstanceId.1': instance_id}
+
+    data, requesturl = query(params, return_url=True)
+
+    blockmap = data[0]['instancesSet']['item']['blockDeviceMapping']
+
+    if type(blockmap['item']) != list:
+        blockmap['item'] = [blockmap['item']]
+
+    items = []
+
+    for idx, item in enumerate(blockmap['item']):
+        device_name = item['deviceName']
+
+        if device is not None and device != device_name:
+            continue
+
+        if volume_id is not None and volume_id != item['ebs']['volumeId']:
+            continue
+
+        info = {
+            'device_name': device_name,
+            'volume_id': item['ebs']['volumeId'],
+            'deleteOnTermination': item['ebs']['deleteOnTermination']
+        }
+
+        items.append(info)
+
+    return items
+
+
+def keepvol_on_destroy(name, kwargs=None, call=None):
     '''
     Do not delete all/specified EBS volumes upon instance termination
 
@@ -1850,11 +1911,17 @@ def keepvol_on_destroy(name, device=None, volume_id=None, call=None):
             'The keepvol_on_destroy action must be called with -a or --action.'
         )
 
+    if not kwargs:
+        kwargs = {}
+
+    device = kwargs.get('device', None)
+    volume_id = kwargs.get('volume_id', None)
+
     return _toggle_delvol(name=name, device=device,
                           volume_id=volume_id, value='false')
 
 
-def delvol_on_destroy(name, device=None, volume_id=None, call=None):
+def delvol_on_destroy(name, kwargs=None, call=None):
     '''
     Delete all/specified EBS volumes upon instance termination
 
@@ -1867,12 +1934,19 @@ def delvol_on_destroy(name, device=None, volume_id=None, call=None):
             'The delvol_on_destroy action must be called with -a or --action.'
         )
 
+    if not kwargs:
+        kwargs = {}
+
+    device = kwargs.get('device', None)
+    volume_id = kwargs.get('volume_id', None)
+
     return _toggle_delvol(name=name, device=device,
                           volume_id=volume_id, value='true')
 
 
 def _toggle_delvol(name=None, instance_id=None, device=None, volume_id=None,
                    value=None, requesturl=None):
+
     if not instance_id:
         instances = list_nodes_full()
         instance_id = instances[name]['instanceId']


### PR DESCRIPTION
Add a <tt>show_delvol_on_destroy</tt> command/action to see the status of the flag.

There were some bugs in #718
- If you attach 1 or more volumes (using <tt>volumes</tt>), the last volume to be attached will not have the flag set. This was because of a loop issue where the <tt>_toggle_delvol</tt> was being invoked before the <tt>attach</tt> API was being invoked.
- The <tt>delvol_on_destroy</tt> and <tt>keepvol_on_destroy</tt> commands were not respecting the keyword arguments (was resulting in 400/Bad request)
