### PR TITLE
Various small fixes

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -114,11 +114,7 @@ class SaltCloud(parsers.SaltCloudParser):
         if self.selected_query_option is not None:
             if self.selected_query_option == 'list_providers':
                 try:
-                    display_output = salt.output.get_printout(
-                        self.options.output, self.config
-                    )
-                    print(display_output(mapper.provider_list()))
-                    self.exit(0)
+                    ret = mapper.provider_list()
                 except (SaltCloudException, Exception) as exc:
                     msg = 'There was an error listing providers: {0}'
                     self.handle_exception(msg, exc)
@@ -143,51 +139,27 @@ class SaltCloud(parsers.SaltCloudParser):
 
         elif self.options.list_locations is not None:
             try:
-                display_output = salt.output.get_printout(
-                    self.options.output, self.config
+                ret = mapper.location_list(
+                    self.options.list_locations
                 )
-                print(
-                    display_output(
-                        mapper.location_list(
-                            self.options.list_locations
-                        )
-                    )
-                )
-                self.exit(0)
             except (SaltCloudException, Exception) as exc:
                 msg = 'There was an error listing locations: {0}'
                 self.handle_exception(msg, exc)
 
         elif self.options.list_images is not None:
             try:
-                display_output = salt.output.get_printout(
-                    self.options.output, self.config
+                ret = mapper.image_list(
+                    self.options.list_images
                 )
-                print(
-                    display_output(
-                        mapper.image_list(
-                            self.options.list_images
-                        )
-                    )
-                )
-                self.exit(0)
             except (SaltCloudException, Exception) as exc:
                 msg = 'There was an error listing images: {0}'
                 self.handle_exception(msg, exc)
 
         elif self.options.list_sizes is not None:
             try:
-                display_output = salt.output.get_printout(
-                    self.options.output, self.config
+                ret = mapper.size_list(
+                    self.options.list_sizes
                 )
-                print(
-                    display_output(
-                        mapper.size_list(
-                            self.options.list_sizes
-                        )
-                    )
-                )
-                self.exit(0)
             except (SaltCloudException, Exception) as exc:
                 msg = 'There was an error listing sizes: {0}'
                 self.handle_exception(msg, exc)

--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -271,10 +271,14 @@ class SaltCloud(parsers.SaltCloudParser):
 
                 msg = ''
                 if 'errors' in dmap:
+                    # display profile errors
                     msg += 'Found the following errors:\n'
                     for profile_name, error in dmap['errors'].iteritems():
                         msg += '  {0}: {1}\n'.format(profile_name, error)
+                    sys.stderr.write(msg)
+                    sys.stderr.flush()
 
+                msg = ''
                 if 'existing' in dmap:
                     msg += ('The following virtual machines were found '
                             'already running:\n')

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -1385,7 +1385,8 @@ class Map(Cloud):
                     obj.values()[0]['ret'] = out[obj.keys()[0]]
                     output.update(obj)
             else:
-                output = output_multip
+                for obj in output_multip:
+                    output.update(obj)
 
         return output
 

--- a/saltcloud/utils/__init__.py
+++ b/saltcloud/utils/__init__.py
@@ -300,6 +300,7 @@ def wait_for_ssh(host, port=22, timeout=900):
         trycount += 1
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(30)
             sock.connect((host, port))
             # Stop any remaining reads/writes on the socket
             sock.shutdown(socket.SHUT_RDWR)


### PR DESCRIPTION
Pull request include several smallish fixes I've been using over the few days:
- 7e1d51d 60 seconds for a socket to timeout is rather long - especially since we then retry the socket for a total of 15 minutes.
- 594ac9a is what should've been done in e101032.
- 0400e0c exit the CLI main method in a single place on success.
- 8282bca display errors in the right place.
- 1d41cec return existing instances in output on map create - this has the added benefit of preventing salt-cloud chucking an error code when running a map file where all nodes already exist (which I believe is not an error state).
