### PR TITLE
digital ocean: added support for new private networking flag

### DIFF
--- a/saltcloud/clouds/digital_ocean.py
+++ b/saltcloud/clouds/digital_ocean.py
@@ -124,6 +124,13 @@ def avail_sizes():
     return ret
 
 
+def avail_private_networks():
+    '''
+    Returns a list of region ids which support private networking.
+    '''
+    return ['4']  # Note: currently only available in NY2 (region id: 4)
+
+
 def list_nodes():
     '''
     Return a list of the VMs that are on the provider
@@ -270,6 +277,17 @@ def create(vm_):
             'The defined key_filename {0!r} does not exist'.format(
                 key_filename
             )
+        )
+
+    private_networking = config.get_config_value(
+        'private_networking', vm_, __opts__, search_global=False, default=None
+    )
+
+    if private_networking and kwargs['region_id'] in avail_private_networks():
+        kwargs['private_networking'] = 'true'
+    else:
+        raise SaltCloudConfigError(
+            'Private networking not available in {0!r}'.format(kwargs['region_id'])
         )
 
     saltcloud.utils.fire_event(


### PR DESCRIPTION
I've added support for Digital Ocean's new private networking flag during node creation. This code checks against the region id to make sure it matches NY2, since this feature is only available there. Available region is encapsulated in a function so that new ones can be added as DO expands. 

The flag can be set in a profile like such:

```
ubuntu_ocean_tiny:
    provider: dig-ocean
    image: Ubuntu 12.04 x64
    size: 512MB
    private_networking: True
```

When the node is deployed, you should see a new field in the api response called `private_ip_address`. 
