### PR TITLE
EC2: add constraint when querying for IP address

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -1052,7 +1052,8 @@ def create(vm_=None, call=None):
 
         if 'ipAddress' in data[0]['instancesSet']['item']:
             return data
-        if 'privateIpAddress' in data[0]['instancesSet']['item']:
+        if ssh_interface(vm_) == 'private_ips' and \
+           'privateIpAddress' in data[0]['instancesSet']['item']:
             return data
 
     try:


### PR DESCRIPTION
When querying for an IP address after instance creation, only return the
private IP address if it's asked for in the profile. This tends to be a
problem when dealing with instances in VPCs, and it takes a while for
the public IP address to be generated.

Fixes saltstack/salt-cloud#693.
