### PR TITLE
Grains were being set improperly on nodes

### DIFF
--- a/doc/topics/aws.rst
+++ b/doc/topics/aws.rst
@@ -23,6 +23,12 @@ Set up the cloud config at ``/etc/salt/cloud``:
         minion:
           master: saltmaster.example.com
   
+        # Set up grains information, which will be common for all nodes
+        # using this provider
+        grains:
+          node_type: broker
+          release: 1.0.1
+
         # Specify whether to use public or private IP for deploy script.
         #
         # Valid options are:

--- a/doc/topics/map.rst
+++ b/doc/topics/map.rst
@@ -63,15 +63,15 @@ A map file can include grains and minion configuration options:
         - web1:
             minion:
                 log_level: debug
-            grains:
-                cheese: tasty
-                omelet: du fromage
+                grains:
+                    cheese: tasty
+                    omelet: du fromage
         - web2:
             minion:
                 log_level: warn
-            grains:
-                cheese: more tasty
-                omelet: with peppers
+                grains:
+                    cheese: more tasty
+                    omelet: with peppers
 
 A map file may also be used with the various query options:
 

--- a/doc/topics/profiles.rst
+++ b/doc/topics/profiles.rst
@@ -27,8 +27,8 @@ public cloud provider. A number of additional parameters can also be inserted:
         minion:
             master: salt.example.com
             append_domain: webs.example.com
-        grains:
-            role: webserver
+            grains:
+                role: webserver
 
 
 The image must be selected from available images. Similarly, sizes must be

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -3,6 +3,7 @@ The top level interface used to translate configuration data back to the
 correct cloud modules
 '''
 # Import python libs
+import copy
 import os
 import glob
 import time
@@ -1064,7 +1065,7 @@ class Map(Cloud):
             profile_data = self.opts['profiles'].get(profile_name)
             for nodename, overrides in nodes.iteritems():
                 # Get the VM name
-                nodedata = profile_data.copy()
+                nodedata = copy.deepcopy(profile_data)
                 # Update profile data with the map overrides
                 for setting in ('grains', 'master', 'minion', 'volumes',
                                 'requires'):


### PR DESCRIPTION
There were some issues in setting grains.
1. When grains are defined in profiles, they used to over-write each other quite randomly. So, grains for one node would appear in the other. This was because while creating the grains, dict.copy() was being used. This would copy references to other dicts and hence cause this problem. The solution is to use deepcopy()
2. Grains set in providers, profiles and map files should behave like derived classes. We can set common grains in providers for all nodes. profile specific grains in profile files and node specific ones in maps. This was not working correctly all the time. There is no issue with the code. In maps/profiles, grains has to be under minion. In providers, grains has to be outside of minion. Updated the documentation to reflect this.
