### PR TITLE
Tired of seeing cloudstack errors on non-cloudstack deployments

### DIFF
--- a/saltcloud/clouds/cloudstack.py
+++ b/saltcloud/clouds/cloudstack.py
@@ -27,8 +27,13 @@ import logging
 import saltcloud.config as config
 from saltcloud.libcloudfuncs import *   # pylint: disable-msg=W0614,W0401
 from saltcloud.utils import namespaced_function
+
 # CloudStackNetwork will be needed during creation of a new node
-from libcloud.compute.drivers.cloudstack import CloudStackNetwork
+try:
+    from libcloud.compute.drivers.cloudstack import CloudStackNetwork
+    HASLIBS=True
+except:
+    HASLIBS=False
 
 # Get logging started
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Technically we don't need the HASLIBS line, but we do it a lot in Salt, and might make use of it here later.
