### PR TITLE
Added IAM Profile for EC2 driver, and a warning on AWS Profile

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -562,6 +562,30 @@ def securitygroup(vm_):
     )
 
 
+def iam_profile(vm_):
+    '''
+    Return the IAM profile.
+
+    The IAM instance profile to associate with the instances.
+    This is either the Amazon Resource Name (ARN) of the instance profile
+    or the name of the role.
+
+    Type: String
+
+    Default: None
+
+    Required: No
+
+    Example: arn:aws:iam::111111111111:instance-profile/s3access
+
+    Example: s3access
+
+    '''
+    return config.get_config_value(
+        'iam_profile', vm_, __opts__, search_global=False
+    )
+
+
 def ssh_username(vm_):
     '''
     Return the ssh_username. Defaults to a built-in list of users for trying.
@@ -800,8 +824,21 @@ def create(vm_=None, call=None):
         if not isinstance(ex_securitygroup, list):
             params[spot_prefix + 'SecurityGroup.1'] = ex_securitygroup
         else:
-            for (counter, sg_) in enumerate(ex_securitygroup):
+            for counter, sg_ in enumerate(ex_securitygroup):
                 params[spot_prefix + 'SecurityGroup.{0}'.format(counter)] = sg_
+
+    ex_iam_profile = iam_profile(vm_)
+    if ex_iam_profile:
+        try:
+            if ex_iam_profile.startswith('arn:aws:iam:'):
+                params['IamInstanceProfile.Arn'] = ex_iam_profile
+            else:
+                params['IamInstanceProfile.Name'] = ex_iam_profile
+        except AttributeError:
+            raise SaltCloudConfigError(
+                '\'iam_profile\' should be a string value.'
+            )
+        pass
 
     az_ = get_availability_zone(vm_)
     if az_ is not None:

--- a/saltcloud/clouds/libcloud_aws.py
+++ b/saltcloud/clouds/libcloud_aws.py
@@ -211,6 +211,15 @@ def securitygroup(vm_):
     )
 
 
+def iam_profile(vm_):
+    '''
+    Return the IAM role
+    '''
+    return config.get_config_value(
+        'iam_profile', vm_, __opts__, search_global=False
+    )
+
+
 def block_device_mappings(vm_):
     '''
     Return the block device mapping
@@ -333,6 +342,17 @@ def create(vm_):
     ex_blockdevicemappings = block_device_mappings(vm_)
     if ex_blockdevicemappings:
         kwargs['ex_blockdevicemappings'] = ex_blockdevicemappings
+
+    ex_iam_profile = iam_profile(vm_)
+    if ex_iam_profile:
+        # libcloud does not implement 'iam_profile' yet.
+        # A pull request has been suggested
+        # https://github.com/apache/libcloud/pull/150
+        raise SaltCloudConfigError(
+            'libcloud does not implement \'iam_profile\' yet. '
+            'Use EC2 driver instead.'
+        )
+
     tags = config.get_config_value('tag', vm_, __opts__, {}, search_global=False)
     if not isinstance(tags, dict):
         raise SaltCloudConfigError(


### PR DESCRIPTION
IAM roles is a nice feature for restricting instances permissions.
http://docs.aws.amazon.com/IAM/latest/APIReference/Welcome.html

I added a new key on EC2 provider:

```
EC2.iam_profile: "iam profile name or iam profile arn"
```

Now, about AWS driver.

While AWS is based on `libcloud`, and it does implement this, currently I raise an Exception, inviting people to try EC2 driver.

I've also pulled a request to `libcloud` https://github.com/apache/libcloud/pull/150 . When it will be accepted, we will remove the exception and finish the implementation.
