### PR TITLE
ec2 set_tags was failing on integer values and values with spaces

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -1429,7 +1429,7 @@ def set_tags(name, tags, call=None, location=None, instance_id=None):
                 # We were not setting this tag
                 continue
 
-            if tags.get(tag['key']) != tag['value']:
+            if str(tags.get(tag['key'])) != str(tag['value']):
                 # Not set to the proper value!?
                 failed_to_set_tags = True
                 break


### PR DESCRIPTION
This fixes a bug I found. I didn't create an issue since the fix was so obvious.

Thank you!
