### PR TITLE
check for strings in tag dict's values. Give a helpful error message.

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -927,6 +927,12 @@ def create(vm_=None, call=None):
                 '\'tag\' should be a dict.'
         )
 
+    for value in tags.values():
+        if not isinstance(value, str):
+            raise SaltCloudConfigError(
+                '\'tag\' values must be strings. Try quoting the values. e.g. "2013-09-19T20:09:46Z".'
+            )
+
     tags['Name'] = vm_['name']
 
     saltcloud.utils.fire_event(


### PR DESCRIPTION
The issue is that tags in map files are being interpreted as python data types when they really need to be uninterpreted strings. For example, a date gets changed to a datetime object, but that is not useful.

The workaround is to quote the values in the map file.

I think the issue of yaml values getting interpreted as python data types is deeper in salt's code than I should change without understanding the wider ramifications. So, I have added some more input checking to warn people if their tag values are getting changed. It suggests the workaround of adding quotes.
