### PR TITLE
use more robust heredoc syntax for updating the minion configuration

### DIFF
--- a/saltcloud/deploy/Arch-git.sh
+++ b/saltcloud/deploy/Arch-git.sh
@@ -15,5 +15,8 @@ cd
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
-echo '{{ minion }}' > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
+
 /etc/rc.d/salt-minion start

--- a/saltcloud/deploy/Arch.sh
+++ b/saltcloud/deploy/Arch.sh
@@ -7,5 +7,8 @@ pacman -Syu --noconfirm salt
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
-echo '{{ minion }}' > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
+
 /etc/rc.d/salt-minion start

--- a/saltcloud/deploy/Debian-git.sh
+++ b/saltcloud/deploy/Debian-git.sh
@@ -3,7 +3,9 @@
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
-echo "{{ minion }}" > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
 
 # echo deb http://ftp.debian.org/debian experimental main | tee -a /etc/apt/sources.list
 echo deb http://backports.debian.org/debian-backports squeeze-backports main | tee -a /etc/apt/sources.list

--- a/saltcloud/deploy/Debian.sh
+++ b/saltcloud/deploy/Debian.sh
@@ -3,7 +3,9 @@
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
-echo "{{ minion }}" > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
 
 # echo deb http://ftp.debian.org/debian experimental main | tee -a /etc/apt/sources.list
 echo deb http://backports.debian.org/debian-backports squeeze-backports main | tee -a /etc/apt/sources.list

--- a/saltcloud/deploy/Fedora-git.sh
+++ b/saltcloud/deploy/Fedora-git.sh
@@ -17,7 +17,10 @@ mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
 # Copy the minion configuration file into place before starting the minion
-echo '{{ minion }}' > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
+
 # Set the minion to start on reboot
 systemctl enable salt-minion.service
 # Start the minion!

--- a/saltcloud/deploy/Fedora.sh
+++ b/saltcloud/deploy/Fedora.sh
@@ -8,7 +8,10 @@ mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
 # Copy the minion configuration file into place before starting the minion
-echo '{{ minion }}' > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
+
 # Set the minion to start on reboot
 systemctl enable salt-minion.service
 # Start the minion!

--- a/saltcloud/deploy/FreeBSD-git.sh
+++ b/saltcloud/deploy/FreeBSD-git.sh
@@ -17,5 +17,8 @@ cd
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /usr/local/etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /usr/local/etc/salt/pki/minion.pub
-echo '{{ minion }}' > /usr/local/etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
+
 salt-minion -d

--- a/saltcloud/deploy/FreeBSD.sh
+++ b/saltcloud/deploy/FreeBSD.sh
@@ -12,6 +12,9 @@ echo 'PACKAGESITE: http://pkgbeta.freebsd.org/freebsd-9-amd64/latest' > /usr/loc
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /usr/local/etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /usr/local/etc/salt/pki/minion.pub
-echo '{{ minion }}' > /usr/local/etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
+
 salt-minion -d
 

--- a/saltcloud/deploy/RHEL5-git.sh
+++ b/saltcloud/deploy/RHEL5-git.sh
@@ -13,6 +13,9 @@ cd
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
-echo '{{ minion }}' > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
+
 /sbin/chkconfig salt-minion on
 service salt-minion start

--- a/saltcloud/deploy/RHEL5.sh
+++ b/saltcloud/deploy/RHEL5.sh
@@ -5,6 +5,9 @@ yum install -y salt-minion
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
-echo '{{ minion }}' > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
+
 /sbin/chkconfig salt-minion on
 service salt-minion start

--- a/saltcloud/deploy/RHEL6-git.sh
+++ b/saltcloud/deploy/RHEL6-git.sh
@@ -13,6 +13,9 @@ cd
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
-echo '{{ minion }}' > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
+
 /sbin/chkconfig salt-minion on
 service salt-minion start

--- a/saltcloud/deploy/RHEL6.sh
+++ b/saltcloud/deploy/RHEL6.sh
@@ -5,6 +5,9 @@ yum -y install salt-minion --enablerepo epel-testing
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
-echo '{{ minion }}' > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
+
 /sbin/chkconfig salt-minion on
 service salt-minion start

--- a/saltcloud/deploy/SmartOS.sh
+++ b/saltcloud/deploy/SmartOS.sh
@@ -15,7 +15,9 @@ easy_install-2.7 salt
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
-echo '{{ minion }}' > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
 
 ###
 # TODO: * create /opt/local/share/smf/salt-minion/manifest.xml in salt.git

--- a/saltcloud/deploy/Ubuntu-git.sh
+++ b/saltcloud/deploy/Ubuntu-git.sh
@@ -3,7 +3,9 @@
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
-echo "{{ minion }}" > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
 
 # add-apt-repository requires an additional dep and is in different packages
 # on different systems. Although seemingly ubiquitous it is not a standard,

--- a/saltcloud/deploy/Ubuntu.sh
+++ b/saltcloud/deploy/Ubuntu.sh
@@ -3,7 +3,9 @@
 mkdir -p /etc/salt/pki
 echo '{{ vm['priv_key'] }}' > /etc/salt/pki/minion.pem
 echo '{{ vm['pub_key'] }}' > /etc/salt/pki/minion.pub
-echo "{{ minion }}" > /etc/salt/minion
+cat > /etc/salt/minion <<EOF
+{{minion}}
+EOF
 
 # add-apt-repository requires an additional dep and is in different packages
 # on different systems. Although seemingly ubiquitous it is not a standard,


### PR DESCRIPTION
it appears that at some point configuration values containing ' snuck into the minion config. this patch will handle unescaped characters like that and many more
