### PR TITLE
Ported block_device_mappings to ec2 provider

### DIFF
--- a/doc/topics/aws.rst
+++ b/doc/topics/aws.rst
@@ -324,7 +324,10 @@ Multiple security groups can also be specified in the same fashion:
 
 Block device mappings enable you to specify additional EBS volumes or instance
 store volumes when the instance is launched. This setting is also available on
-each cloud profile.
+each cloud profile. Note that the number of instance stores varies by instance type.
+If more mappings are provided than are supported by the instance type, mappings will be
+created in the order provided and additional mappings will be ignored. Consult the
+`AWS documentation`_ for a listing of the available instance stores, device names, and mount points.
 
 .. code-block:: yaml
 
@@ -345,6 +348,7 @@ Tags can be set once an instance has been launched.
             tag0: value
             tag2: value
 
+.. _`AWS documentation`: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html
 
 Modify EC2 Tags
 ===============

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -742,6 +742,16 @@ def list_availability_zones():
     return ret
 
 
+def block_device_mappings(vm_):
+    '''
+    Return the block device mapping
+    e.g. [{'DeviceName': '/dev/sdb', 'VirtualName': 'ephemeral0'},
+          {'DeviceName': '/dev/sdc', 'VirtualName': 'ephemeral1'}]
+    '''
+    return config.get_config_value(
+        'block_device_mappings', vm_, __opts__, search_global=True
+    )
+
 def create(vm_=None, call=None):
     '''
     Create a single VM from a data dict
@@ -855,6 +865,12 @@ def create(vm_=None, call=None):
         else:
             for (counter, sg_) in enumerate(ex_securitygroupid):
                 params[spot_prefix + 'SecurityGroupId.{0}'.format(counter)] = sg_
+
+    ex_blockdevicemappings = block_device_mappings(vm_)
+    if ex_blockdevicemappings:
+        for (idx, block_device_mapping) in enumerate(ex_blockdevicemappings):
+            params['BlockDeviceMapping.%d.DeviceName' % idx] = block_device_mapping['DeviceName']
+            params['BlockDeviceMapping.%d.VirtualName' % idx] = block_device_mapping['VirtualName']
 
     set_del_root_vol_on_destroy = config.get_config_value(
         'del_root_vol_on_destroy', vm_, __opts__, search_global=False


### PR DESCRIPTION
This functionality (which allows for ephemeral storage setup) was previously only available in the AWS provider. Documentation has also been updated to prevent confusion when setting up block devices on unsupported instance types.

 Fixes #845
