### PR TITLE
Add support for Rackspace Managed service level

### DIFF
--- a/doc/topics/rackspace.rst
+++ b/doc/topics/rackspace.rst
@@ -164,7 +164,6 @@ from stomping over the bootstrapping you can add the below to your profiles.
         image: Ubuntu 12.04 LTS (Precise Pangolin)
         managedcloud: True
 
-
 First and Next Generation Images
 --------------------------------
 

--- a/doc/topics/rackspace.rst
+++ b/doc/topics/rackspace.rst
@@ -146,6 +146,25 @@ to your profiles:
         image: Ubuntu 12.04 LTS (Precise Pangolin)
         rackconnect: True
 
+Managed Cloud Environments
+--------------------------------
+
+Rackspace offers a managed service level of hosting. As part of the managed service level
+you have the ability to choose from base of lamp installations on cloud server images.
+The post build process for both the base and the lamp installations used Chef to install
+things such as the cloud monitoring agent and the cloud backup agent. It also takes care of
+installing the lamp stack if selected. In order to prevent the post installation process
+from stomping over the bootstrapping you can add the below to your profiles.
+
+.. code-block:: yaml
+
+    openstack_512:
+        provider: my-rackspace-config
+        size: 512MB Standard Instance
+        image: Ubuntu 12.04 LTS (Precise Pangolin)
+        managedcloud: True
+
+
 First and Next Generation Images
 --------------------------------
 

--- a/saltcloud/clouds/openstack.py
+++ b/saltcloud/clouds/openstack.py
@@ -288,6 +288,16 @@ def rackconnect(vm_):
         search_global=False
     )
 
+def managedcloud(vm_):
+    '''
+    Determine if we should wait for the managed cloud automation before running. Either
+    'False' (default) or 'True'.
+    '''
+    return config.get_config_value(
+        'managedcloud', vm_, __opts__, default='False',
+        search_global=False
+    )
+
 def create(vm_):
     '''
     Create a single VM from a data dict
@@ -447,6 +457,14 @@ def create(vm_):
 
             if rc_status != 'DEPLOYED':
                 log.debug('Waiting for Rackconnect automation to complete')
+                return
+
+        if managedcloud(vm_) is True:
+            extra = nodelist[vm_['name']].get('extra')
+            mc_status = extra.get('metadata').get('rax_service_level_automation')
+
+            if mc_status != 'Complete':
+                log.debug('Waiting for managed cloud automation to complete')
                 return
 
         private = nodelist[vm_['name']]['private_ips']


### PR DESCRIPTION
This patch will wait for the Rackspace managed kick script to complete before continuing with the bootstrapping. Doing this will stop the setup of the minion from also attempting to install packages while the Rackspace install process is still running. Completion of the process is determined by checking the value of the "rax_service_level_automation" key.
