### PR TITLE
Add windows functionality to saltify

### DIFF
--- a/saltcloud/clouds/saltify.py
+++ b/saltcloud/clouds/saltify.py
@@ -144,7 +144,13 @@ def create(vm_):
         {'kwargs': deploy_kwargs},
     )
 
-    deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
+
+    # The following line is for future Python 3 compatibility
+    deployed = False
+    if win_installer:
+        deployed = saltcloud.utils.deploy_windows(**deploy_kwargs)
+    else:
+        deployed = saltcloud.utils.deploy_script(**deploy_kwargs)
     if deployed:
         ret['deployed'] = deployed
         log.info('Salt installed on {0}'.format(vm_['name']))


### PR DESCRIPTION
This lets us test the windows deploy script without having to wait for the windows instance to be created.

Tagging @UtahDave.
