### PR TITLE
Fixing Digital Ocean VMs being ignored in delete map commands

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -914,7 +914,7 @@ class Map(Cloud):
                 for vm_name, vm_details in vms.copy().iteritems():
                     if vm_details == 'Absent':
                         query_map[alias][driver].pop(vm_name)
-                    elif vm_details['state'].lower() != 'running':
+                    elif vm_details['state'].lower() != 'running' and vm_details['state'].lower() != 'active':
                         query_map[alias][driver].pop(vm_name)
                 if not query_map[alias][driver]:
                     query_map[alias].pop(driver)


### PR DESCRIPTION
DO NOT MERGE RIGHT AWAY! PLEASE READ!

This is the simple quick fix, but might not be the right approach. I believe the apache cloud lib normalizes the vm state data so that if a VM is up and running it returns a state of "running." However, because the digital ocean API is used directly, it returns the state as "Active", hence it gets popped out of the list.

A better fix than what I have bellow is having the Digital Ocean driver normalize the value from active to running, but I Don't know if that would break anything for others. So hence I'm asking which approach we should do. :)

This pull request is in response to the issue #875
