### PR TITLE
Added ability to create persistent spot instances on EC2

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -800,7 +800,7 @@ def create(vm_=None, call=None):
 
         params = {'Action': 'RequestSpotInstances',
                   'InstanceCount': '1',
-                  'Type': 'one-time',
+                  'Type': spot_config['type'] if 'type' in spot_config else 'one-time',
                   'SpotPrice': spot_config['spot_price']}
 
         # All of the necessary launch parameters for a VM when using


### PR DESCRIPTION
EC2 supports the ability to create one-time or persistent spot instances. The difference is that persistent instances will automatically start back up again if they are shut down by Amazon due to price adjustment.

Example:

test-server:
  spot_config:
    type: persistent
    spot_price: 1

It still defaults to a "one-time" instance if "type" is not specified so it should function the same as before unless someone specifically wants a persistent spot.
