### PR TITLE
Remove duplicate entries in documentation

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -18,5 +18,3 @@ Salt Cloud Table of Contents
     ref/cli/man/salt-cloud
 
     topics/releases/index
-    topics/releases/0.6.0
-    topics/releases/0.7.0


### PR DESCRIPTION
The two release notes are also included in _topics/releases/index_ thus they
appeared twice in the documentation.
