### PR TITLE
Allow resize root device for AWS instances. Enable full vpc-based deployment.

### DIFF
--- a/doc/topics/aws.rst
+++ b/doc/topics/aws.rst
@@ -338,6 +338,17 @@ created in the order provided and additional mappings will be ignored. Consult t
         - DeviceName: /dev/sdc
           VirtualName: ephemeral1
 
+You can also use block device mappings to change the size of the root device at the 
+provisioing time. For example, assuming the root device is '/dev/sda', you can set 
+its size to 100G by using the following configuration.
+
+.. code-block:: yaml
+
+    my-ec2-config:
+      block_device_mappings:
+        - DeviceName: /dev/sda
+          Ebs.VolumeSize: 100 
+
 
 Tags can be set once an instance has been launched.
 


### PR DESCRIPTION
The first three commits enable users to change the size of the root device for EC2 instances. In fact, with these changes, it is also possible to add volumes at the provisioning time ( by specifying "BlockDeviceMapping.n.Ebs.SnapshotId" and "BlockDeviceMapping.n.Ebs.VolumeSize"). 

---

The fourth commit is about a separate issue. But I happened pushed it. And I hope it could be accepted.

In typical VPC-based infrastructures, subnets are categorised into 'public subnet' and 'private subnet'. Refer to this doc, http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Scenario2.html, for details. In short, private subnet will use a NAT instance as the internet gateway, while public subnet will use the default internet gateway created for the VPC.

When using salt-cloud to instrument such infrastructures, instances in private subnets are easy to deal. Once the instance is launched in a private subnet, it has internet connections as long as the NAT instance is running and hence the deploy script from salt-cloud works fine.

However, when launching instances in public subnets, salt-cloud most likely won't be able to config those instance. It says 'most likely' because if the subnet happens to be the default subnet in the default VPC, the instance could receive a public ip and obtain internet access immediately after booting up. But to the majority, non-default VPC and non-default subnet, no public ip will be assigned to instances running in them by default.

In order to enable salt-cloud to config instances launched in non-default public subnets, we need to utilise the new feature introduced in AWS API version 2013-10-01. Network interfaces can be configured and a public ip address can be requested  for the instance to be launched. 

With this commit, users can use salt-cloud to launch and config instances in public subnets by using configuration similar to the following one.

<pre>
network_interfaces:
        - DeviceIndex: 0
          AssociatePublicIpAddress: True # Ask AWS to assign a public ip automatically
          SubnetId: subnet-94ac27fc
          SecurityGroupId:
              - sg-27f31148
              - sg-26f31149
</pre>


It is also possible to pre-assign private ips to instances using this configuration. This cloud be useful to gain full control over the ip addresses (e.g. separate fixed ips and dhcp ips).The example is given below. 

<pre>
network_interfaces:
        - DeviceIndex: 0
          PrivateIpAddresses:
               - Primary: True
                 PrivateIpAddress: 10.0.0.101
          AssociatePublicIpAddress: True
          SubnetId: subnet-94ac27fc
          SecurityGroupId:
              - sg-27f31148
              - sg-26f31149
</pre>


I make the AWS API version as a configuration in this commit. So users can try new version of APIs without patching the source.
