### PR TITLE
Allow 'minion' to be absent in cloud.profiles entries - fixes #701

### DIFF
--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -1099,7 +1099,7 @@ class Map(Cloud):
                 # merge minion grains from map file
                 if 'minion' in overrides:
                     if 'grains' in overrides['minion']:
-                        if 'grains' in nodedata['minion']:
+                        if 'grains' in nodedata.get('minion', {}):
                             nodedata['minion']['grains'].update(
                                 overrides['minion']['grains']
                             )


### PR DESCRIPTION
Prior to this patch, you'd get the following traceback if you didn't specify a 'minion' key in an entry in /etc/salt/cloud.profiles:

$ sudo salt-cloud -m /etc/salt/cloud.map
[INFO    ] salt-cloud starting
[INFO    ] Applying map from '/etc/salt/cloud.map'.
[ERROR   ] There was a query error: 'minion'
Traceback (most recent call last):
  File "/opt/salt-cloud/src/salt-cloud/saltcloud/cli.py", line 273, in run
    dmap = mapper.map_data()
  File "/opt/salt-cloud/src/salt-cloud/saltcloud/cloud.py", line 1102, in map_data
    if 'grains' in nodedata['minion']:
KeyError: 'minion'
