### PR TITLE
Fix Issue #894, Make cli action option works with map file.

### DIFF
--- a/saltcloud/cli.py
+++ b/saltcloud/cli.py
@@ -198,7 +198,7 @@ class SaltCloud(parsers.SaltCloudParser):
                                       self.config.get('map', None)):
             if self.config.get('map', None):
                 log.info('Applying map from {0!r}.'.format(self.config['map']))
-                names = mapper.delete_map(query='list_nodes')
+                names = mapper.get_vmnames_by_action(self.options.action)
             else:
                 names = self.config.get('names', None)
 

--- a/saltcloud/cloud.py
+++ b/saltcloud/cloud.py
@@ -923,6 +923,22 @@ class Map(Cloud):
                 query_map.pop(alias)
         return query_map
 
+    def get_vmnames_by_action(self, action):
+        query_map = self.interpolated_map("list_nodes")
+        matching_states = {
+            "start" : ["stopped"],
+            "stop" : ["running", "active"],
+            "reboot" : ["running", "active"],
+        }
+        vm_names = []
+        for alias, drivers in query_map.iteritems():
+            for driver, vms in drivers.iteritems():
+                for vm_name, vm_details in vms.iteritems():
+                    if (vm_details != 'Absent') and \
+                        (vm_details['state'].lower() in matching_states[action]):
+                        vm_names.append(vm_name)
+        return vm_names
+
     def read(self):
         '''
         Read in the specified map file and return the map structure


### PR DESCRIPTION
Add get_vmnames_by_action in cloud.py Map, used for getting available names from map file, call get_vmnames_by_action when use action option in cli with map file.

After this patch, 

``` bash
salt-cloud -a start -m /etc/salt/maps/example.map
salt-cloud -a stop -m /etc/salt/maps/example.map
```

can get the correct available vm names from map file and work correctly. For "start" action only vms with state "stopped" are returned. For "stop" and "reboot" actions, vms with state "running" or "active" are returned. 
