### PR TITLE
Update index.rst

### DIFF
--- a/salt_cloud/doc/topics/install/index.rst
+++ b/salt_cloud/doc/topics/install/index.rst
@@ -17,7 +17,7 @@ Clone the repository using:
 
 .. code-block:: bash
 
-    git clone https://github.com/saltstack/salt-cloud.git
+    git clone https://github.com/saltstack/salt.git
 
 
 Create a new `virtualenv`_:
@@ -50,14 +50,14 @@ Activate the virtualenv:
 
 .. _dependencies:
 
-Install Salt Cloud (and dependencies) into the virtualenv:
+Install Salt (which contains Salt Cloud) (and dependencies) into the virtualenv:
 
 .. code-block:: bash
 
     pip install M2Crypto    # Don't install on Debian/Ubuntu (see below)
-    pip install pyzmq PyYAML pycrypto msgpack-python jinja2 psutil salt
+    pip install pyzmq PyYAML pycrypto msgpack-python jinja2 psutil
     pip install apache-libcloud
-    pip install -e ./salt-cloud   # the path to the salt-cloud git clone
+    pip install -e ./salt   # the path to the salt-cloud git clone
 
 
 .. note:: Installing M2Crypto


### PR DESCRIPTION
Salt itself now contains salt-cloud. As these instructions are written, they do not work because when you clone salt-cloud, the main source is not in this top-level directory but on level lower in the same-named directory (salt-cloud). 

The README in the salt-cloud docs states: 

"The Salt team is excited to report that the `salt-cloud` repository has been
merged into the main Salt repository."
