### PR TITLE
add note that salt-cloud was merged into salt.

### DIFF
--- a/salt_cloud/doc/topics/install/index.rst
+++ b/salt_cloud/doc/topics/install/index.rst
@@ -1,5 +1,6 @@
 Install Salt Cloud
 ==================
+Salt Cloud is now part of Salt proper. It was merged in as of Salt version 2014.1.0.
 
 Salt Cloud has only two dependencies:
 


### PR DESCRIPTION
In case someone hits this page directly from a google search, added a note to say that salt-cloud is now part of salt proper.
